### PR TITLE
Adding HotReload support for development

### DIFF
--- a/build/Package.props
+++ b/build/Package.props
@@ -23,7 +23,13 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageProjectUrl>https://github.com/Onebeld/PleasantUI</PackageProjectUrl>
     </PropertyGroup>
-
+    
+    <ItemGroup>
+        <PackageReference Include="HotAvalonia" Version="3.*" PrivateAssets="All" Publish="True" />
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="*" PrivateAssets="All" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.0.0" PrivateAssets="All" />
+    </ItemGroup>
+    
     <ItemGroup>
         <AdditionalFiles Include="**\*.axaml"/>
         <Compile Update="**\*.axaml.cs"/>

--- a/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
+++ b/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
@@ -12,6 +12,11 @@
         <ApplicationIcon>PleasantUIIcon.ico</ApplicationIcon>
         <IncludeAvaloniaGenerators>true</IncludeAvaloniaGenerators>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+        <DebugType>embedded</DebugType>
+        <IncludeSymbolsInSingleFile>true</IncludeSymbolsInSingleFile>
+    </PropertyGroup>
     
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="12.0.0" />

--- a/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
+++ b/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
@@ -16,13 +16,25 @@
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
         <DebugType>embedded</DebugType>
         <IncludeSymbolsInSingleFile>true</IncludeSymbolsInSingleFile>
+        <DefineConstants>$(DefineConstants);ENABLE_XAML_HOT_RELOAD</DefineConstants>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <LibrarySourcePath>$(MSBuildProjectDirectory)\..\..\src\PleasantUI</LibrarySourcePath>
+    </PropertyGroup>
+    <ItemGroup>
+        <!-- Передаем путь как константу компиляции -->
+        <CompilerVisibleProperty Include="LibrarySourcePath" />
+    </ItemGroup>
     
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="12.0.0" />
         <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
         <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="9.0.8" />
+        <PackageReference Include="HotAvalonia" Version="3.*" PrivateAssets="All" Publish="True" />
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="*" PrivateAssets="All" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.0.0" PrivateAssets="All" />
     </ItemGroup>
     
     <ItemGroup>

--- a/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
+++ b/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
@@ -13,20 +13,6 @@
         <IncludeAvaloniaGenerators>true</IncludeAvaloniaGenerators>
     </PropertyGroup>
     
-    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-        <DebugType>embedded</DebugType>
-        <IncludeSymbolsInSingleFile>true</IncludeSymbolsInSingleFile>
-        <DefineConstants>$(DefineConstants);ENABLE_XAML_HOT_RELOAD</DefineConstants>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <LibrarySourcePath>$(MSBuildProjectDirectory)\..\..\src\PleasantUI</LibrarySourcePath>
-    </PropertyGroup>
-    <ItemGroup>
-        <!-- Передаем путь как константу компиляции -->
-        <CompilerVisibleProperty Include="LibrarySourcePath" />
-    </ItemGroup>
-    
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="12.0.0" />
         <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />

--- a/samples/PleasantUI.Example/Factories/ControlPageCardsFactory.cs
+++ b/samples/PleasantUI.Example/Factories/ControlPageCardsFactory.cs
@@ -18,16 +18,16 @@ public class ControlPageCardsFactory
     {
         return
         [
-            new("CardTitle/Button",       MaterialIcons.ButtonCursor,        "Card/Button",    new ButtonPage(),   _eventAggregator),
-            new("CardTitle/Checkbox",     MaterialIcons.CheckboxMarkedOutline,"Card/Checkbox",  new CheckBoxPage(), _eventAggregator),
-            new("CardTitle/Progress",     MaterialIcons.ProgressHelper,       "Card/Progress",  new ProgressPage(), _eventAggregator),
-            new("CardTitle/Calendar",     MaterialIcons.CalendarOutline,      "Card/Calendar",  new CalendarPage(), _eventAggregator),
-            new("CardTitle/Carousel",     MaterialIcons.ViewCarouselOutline,  "Card/Carousel",  new CarouselPage(), _eventAggregator),
-            new("CardTitle/ComboBox",     MaterialIcons.ExpandAllOutline,     "Card/ComboBox",  new ComboBoxPage(), _eventAggregator),
-            new("CardTitle/TextBox",      MaterialIcons.FormTextbox,          "Card/TextBox",   new TextBoxPage(),  _eventAggregator),
-            new("CardTitle/DataGrid",     MaterialIcons.Grid,                 "Card/DataGrid",  new DataGridPage(), _eventAggregator),
-            new("CardTitle/PinCode",      MaterialIcons.KeyboardOutline,       "Card/PinCode",   new PinCodePage(),  _eventAggregator),
-            new("CardTitle/SelectionList", MaterialIcons.ViewListOutline, "Card/SelectionList", new SelectionListPage(), _eventAggregator),
+            new("CardTitle/Button",       MaterialIcons.ButtonCursor,        "Card/Button", () =>  new ButtonPage(),   _eventAggregator),
+            new("CardTitle/Checkbox",     MaterialIcons.CheckboxMarkedOutline,"Card/Checkbox", () =>  new CheckBoxPage(), _eventAggregator),
+            new("CardTitle/Progress",     MaterialIcons.ProgressHelper,       "Card/Progress", () =>  new ProgressPage(), _eventAggregator),
+            new("CardTitle/Calendar",     MaterialIcons.CalendarOutline,      "Card/Calendar", () =>  new CalendarPage(), _eventAggregator),
+            new("CardTitle/Carousel",     MaterialIcons.ViewCarouselOutline,  "Card/Carousel", () =>  new CarouselPage(), _eventAggregator),
+            new("CardTitle/ComboBox",     MaterialIcons.ExpandAllOutline,     "Card/ComboBox", () =>  new ComboBoxPage(), _eventAggregator),
+            new("CardTitle/TextBox",      MaterialIcons.FormTextbox,          "Card/TextBox", () =>   new TextBoxPage(),  _eventAggregator),
+            new("CardTitle/DataGrid",     MaterialIcons.Grid,                 "Card/DataGrid", () =>  new DataGridPage(), _eventAggregator),
+            new("CardTitle/PinCode",      MaterialIcons.KeyboardOutline,       "Card/PinCode", () =>   new PinCodePage(),  _eventAggregator),
+            new("CardTitle/SelectionList", MaterialIcons.ViewListOutline, "Card/SelectionList", () => new SelectionListPage(), _eventAggregator),
         ];
     }
 
@@ -35,28 +35,28 @@ public class ControlPageCardsFactory
     {
         return
         [
-            new("CardTitle/PleasantSnackbar",    MaterialIcons.InformationOutline,    "Card/PleasantSnackbar",    new PleasantSnackbarPage(),    _eventAggregator),
-            new("CardTitle/InformationBlock",    MaterialIcons.InformationBoxOutline, "Card/InformationBlock",    new InformationBlockPage(),    _eventAggregator),
-            new("CardTitle/OptionsDisplayItem",  MaterialIcons.ViewListOutline,       "Card/OptionsDisplayItem",  new OptionsDisplayItemPage(),  _eventAggregator),
-            new("CardTitle/PleasantTabView",     MaterialIcons.Tab,                   "Card/PleasantTabView",     new PleasantTabViewPage(),     _eventAggregator),
-            new("CardTitle/PleasantMenu",        MaterialIcons.MenuOpen,              "Card/PleasantMenu",        new PleasantMenuPage(),        _eventAggregator),
-            new("CardTitle/Timeline",            MaterialIcons.TimelineOutline,       "Card/Timeline",            new TimelinePage(),            _eventAggregator),
-            new("CardTitle/InstallWizard",       MaterialIcons.WizardHat,             "Card/InstallWizard",       new InstallWizardPage(),       _eventAggregator),
-            new("CardTitle/PleasantDrawer",      MaterialIcons.DrawingBox,    "Card/PleasantDrawer",      new PleasantDrawerPage(),      _eventAggregator),
-            new("CardTitle/PopConfirm",          MaterialIcons.CheckboxMarkedCircle,  "Card/PopConfirm",          new PopConfirmPage(),          _eventAggregator),
-            new("CardTitle/PathPicker",          MaterialIcons.FolderOpenOutline,     "Card/PathPicker",          new PathPickerPage(),          _eventAggregator),
-            new("CardTitle/PleasantMiniWindow",  MaterialIcons.WindowMinimize,        "Card/PleasantMiniWindow",  new PleasantMiniWindowPage(),  _eventAggregator),
-            new("CardTitle/BreadcrumbBar",       MaterialIcons.PageNextOutline,        "Card/BreadcrumbBar",       new BreadcrumbBarPage(),       _eventAggregator),
-            new("CardTitle/CommandBar",          MaterialIcons.ViewGridOutline,        "Card/CommandBar",          new CommandBarPage(),          _eventAggregator),
-            new("CardTitle/DashboardCard",       MaterialIcons.ViewDashboardOutline,   "Card/DashboardCard",       new DashboardCardPage(),       _eventAggregator),
-            new("CardTitle/LogViewerPanel",      MaterialIcons.TextBoxOutline,         "Card/LogViewerPanel",      new LogViewerPanelPage(),      _eventAggregator),
-            new("CardTitle/TerminalPanel",       MaterialIcons.ConsoleLine,            "Card/TerminalPanel",       new TerminalPanelPage(),       _eventAggregator),
-            new("CardTitle/TreeViewPanel",       MaterialIcons.FileTreeOutline,        "Card/TreeViewPanel",       new TreeViewPanelPage(),       _eventAggregator),
-            new("CardTitle/ItemListPanel",       MaterialIcons.FormatListBulletedType, "Card/ItemListPanel",       new ItemListPanelPage(),       _eventAggregator),
-            new("CardTitle/StepDialog",          MaterialIcons.OrderNumericAscending,  "Card/StepDialog",          new StepDialogPage(),          _eventAggregator),
-            new("CardTitle/PropertyGrid",        MaterialIcons.TableColumnPlusAfter,   "Card/PropertyGrid",        new PropertyGridPage(),        _eventAggregator),
-            new("CardTitle/DownloadPanel",       MaterialIcons.DownloadOutline,        "Card/DownloadPanel",       new DownloadPanelPage(),       _eventAggregator),
-            new("CardTitle/CrashReportDialog",   MaterialIcons.BugOutline,             "Card/CrashReportDialog",   new CrashReportDialogPage(),   _eventAggregator),
+            new("CardTitle/PleasantSnackbar",    MaterialIcons.InformationOutline,    "Card/PleasantSnackbar", () =>    new PleasantSnackbarPage(),    _eventAggregator),
+            new("CardTitle/InformationBlock",    MaterialIcons.InformationBoxOutline, "Card/InformationBlock", () =>    new InformationBlockPage(),    _eventAggregator),
+            new("CardTitle/OptionsDisplayItem",  MaterialIcons.ViewListOutline,       "Card/OptionsDisplayItem", () =>  new OptionsDisplayItemPage(),  _eventAggregator),
+            new("CardTitle/PleasantTabView",     MaterialIcons.Tab,                   "Card/PleasantTabView", () =>     new PleasantTabViewPage(),     _eventAggregator),
+            new("CardTitle/PleasantMenu",        MaterialIcons.MenuOpen,              "Card/PleasantMenu", () =>        new PleasantMenuPage(),        _eventAggregator),
+            new("CardTitle/Timeline",            MaterialIcons.TimelineOutline,       "Card/Timeline", () =>            new TimelinePage(),            _eventAggregator),
+            new("CardTitle/InstallWizard",       MaterialIcons.WizardHat,             "Card/InstallWizard", () =>       new InstallWizardPage(),       _eventAggregator),
+            new("CardTitle/PleasantDrawer",      MaterialIcons.DrawingBox,    "Card/PleasantDrawer", () =>      new PleasantDrawerPage(),      _eventAggregator),
+            new("CardTitle/PopConfirm",          MaterialIcons.CheckboxMarkedCircle,  "Card/PopConfirm", () =>          new PopConfirmPage(),          _eventAggregator),
+            new("CardTitle/PathPicker",          MaterialIcons.FolderOpenOutline,     "Card/PathPicker", () =>          new PathPickerPage(),          _eventAggregator),
+            new("CardTitle/PleasantMiniWindow",  MaterialIcons.WindowMinimize,        "Card/PleasantMiniWindow", () =>  new PleasantMiniWindowPage(),  _eventAggregator),
+            new("CardTitle/BreadcrumbBar",       MaterialIcons.PageNextOutline,        "Card/BreadcrumbBar", () =>       new BreadcrumbBarPage(),       _eventAggregator),
+            new("CardTitle/CommandBar",          MaterialIcons.ViewGridOutline,        "Card/CommandBar", () =>          new CommandBarPage(),          _eventAggregator),
+            new("CardTitle/DashboardCard",       MaterialIcons.ViewDashboardOutline,   "Card/DashboardCard", () =>       new DashboardCardPage(),       _eventAggregator),
+            new("CardTitle/LogViewerPanel",      MaterialIcons.TextBoxOutline,         "Card/LogViewerPanel", () =>      new LogViewerPanelPage(),      _eventAggregator),
+            new("CardTitle/TerminalPanel",       MaterialIcons.ConsoleLine,            "Card/TerminalPanel", () =>       new TerminalPanelPage(),       _eventAggregator),
+            new("CardTitle/TreeViewPanel",       MaterialIcons.FileTreeOutline,        "Card/TreeViewPanel", () =>       new TreeViewPanelPage(),       _eventAggregator),
+            new("CardTitle/ItemListPanel",       MaterialIcons.FormatListBulletedType, "Card/ItemListPanel", () =>       new ItemListPanelPage(),       _eventAggregator),
+            new("CardTitle/StepDialog",          MaterialIcons.OrderNumericAscending,  "Card/StepDialog", () =>          new StepDialogPage(),          _eventAggregator),
+            new("CardTitle/PropertyGrid",        MaterialIcons.TableColumnPlusAfter,   "Card/PropertyGrid", () =>        new PropertyGridPage(),        _eventAggregator),
+            new("CardTitle/DownloadPanel",       MaterialIcons.DownloadOutline,        "Card/DownloadPanel", () =>       new DownloadPanelPage(),       _eventAggregator),
+            new("CardTitle/CrashReportDialog",   MaterialIcons.BugOutline,             "Card/CrashReportDialog", () =>   new CrashReportDialogPage(),   _eventAggregator),
         ];
     }
 
@@ -64,8 +64,8 @@ public class ControlPageCardsFactory
     {
         return
         [
-            new("CardTitle/MessageBox", MaterialIcons.MessageOutline, "Card/MessageBox", new MessageBoxPage(), _eventAggregator),
-            new("CardTitle/Docking",    MaterialIcons.ViewDashboardOutline, "Card/Docking", new DockingPage(), _eventAggregator),
+            new("CardTitle/MessageBox", MaterialIcons.MessageOutline, "Card/MessageBox", () => new MessageBoxPage(), _eventAggregator),
+            new("CardTitle/Docking",    MaterialIcons.ViewDashboardOutline, "Card/Docking", () => new DockingPage(), _eventAggregator),
         ];
     }
 }

--- a/samples/PleasantUI.Example/Models/ControlPageCard.cs
+++ b/samples/PleasantUI.Example/Models/ControlPageCard.cs
@@ -19,7 +19,7 @@ public class ControlPageCard : INotifyPropertyChanged
     public string TitleKey { get; }
     public string DescriptionKey { get; }
     public Geometry Icon { get; set; }
-    public IPage Page { get; set; }
+    public Func<IPage> Page { get; set; }
 
     public string Title
     {
@@ -43,7 +43,7 @@ public class ControlPageCard : INotifyPropertyChanged
         }
     }
 
-    public ControlPageCard(string titleKey, Geometry icon, string descriptionKey, IPage page, IEventAggregator eventAggregator)
+    public ControlPageCard(string titleKey, Geometry icon, string descriptionKey, Func<IPage> page, IEventAggregator eventAggregator)
     {
         _eventAggregator = eventAggregator;
         TitleKey = titleKey;
@@ -79,5 +79,5 @@ public class ControlPageCard : INotifyPropertyChanged
         Localizer.Instance.TryGetString(key, out string value) ? value : key;
 
     public void OpenPage() =>
-        _eventAggregator.PublishAsync(new ChangePageMessage(Page));
+        _eventAggregator.PublishAsync(new ChangePageMessage(Page.Invoke()));
 }

--- a/samples/PleasantUI.Example/PleasantUI.Example.csproj
+++ b/samples/PleasantUI.Example/PleasantUI.Example.csproj
@@ -23,6 +23,9 @@
     <ItemGroup>
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
         <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="HotAvalonia" Version="3.*" PrivateAssets="All" Publish="True" />
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="*" PrivateAssets="All" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.0.0" PrivateAssets="All" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
Adds HotReload support, primarily to speed up development of the sample app.

The sample app also has a different page layout: now, when clicking the buttons to navigate to a page with controls, that page is dynamically created. This was done because hot reloading with a hotkey didn't open the page.

Hot reload support isn't yet available for controls from the PleasanUI core library; I'm investigating this issue. I'll post an update here.