### PR TITLE
ci(canary-release): Add commit check job to skip redundant releases

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -15,7 +15,50 @@ on:
         default: false
 
 jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    outputs:
+      has_new_commits: ${{ steps.check.outputs.has_new_commits }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for new commits since last canary
+        id: check
+        run: |
+          # PR and manual triggers always proceed
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "Trigger is '${{ github.event_name }}' — skipping commit check."
+            echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --tags origin
+
+          # Find the most recent canary tag
+          LAST_CANARY=$(git tag --list 'v*-canary-*' --sort=-creatordate | head -1)
+
+          if [ -z "$LAST_CANARY" ]; then
+            echo "No previous canary tag found — proceeding."
+            echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Last canary tag: $LAST_CANARY"
+          COMMIT_COUNT=$(git rev-list "${LAST_CANARY}..HEAD" --count)
+          echo "New commits since $LAST_CANARY: $COMMIT_COUNT"
+
+          if [ "$COMMIT_COUNT" -eq 0 ]; then
+            echo "No new commits since last canary — skipping workflow."
+            echo "has_new_commits=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_new_commits=true" >> "$GITHUB_OUTPUT"
+          fi
+
   canary:
+    needs: check-commits
+    if: needs.check-commits.outputs.has_new_commits == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
- Add new `check-commits` job that runs before canary release
- Detect new commits since last canary tag using git rev-list
- Skip workflow execution when no new commits exist on scheduled runs
- Allow PR and manual triggers to bypass commit check and proceed
- Output `has_new_commits` flag for downstream job dependency
- Prevents unnecessary canary releases and reduces build overhead