### PR TITLE
Fixes PleasantMiniWindow title bar button bindings, and adds option to remove close button.

### DIFF
--- a/build/Package.props
+++ b/build/Package.props
@@ -23,7 +23,13 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageProjectUrl>https://github.com/Onebeld/PleasantUI</PackageProjectUrl>
     </PropertyGroup>
-
+    
+    <ItemGroup>
+        <PackageReference Include="HotAvalonia" Version="3.*" PrivateAssets="All" Publish="True" />
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="*" PrivateAssets="All" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.0.0" PrivateAssets="All" />
+    </ItemGroup>
+    
     <ItemGroup>
         <AdditionalFiles Include="**\*.axaml"/>
         <Compile Update="**\*.axaml.cs"/>

--- a/docs/PleasantMiniWindow.md
+++ b/docs/PleasantMiniWindow.md
@@ -29,7 +29,8 @@ public partial class MyToolWindow : PleasantMiniWindow
 | `EnableCustomTitleBar` | `bool` | from settings | Replaces the OS title bar with the minimal Fluent one |
 | `EnableBlur` | `bool` | from settings | Acrylic/blur background |
 | `ShowPinButton` | `bool` | `true` | Shows the pin (always-on-top) toggle button |
-| `ShowHiddenButton` | `bool` | `false` | Shows a minimize button |
+| `ShowMinimizedButton` | `bool` | `false` | Shows a minimize button |
+| `ShowClosedButton` | `bool` | `true` | Shows a close button |
 
 ## Showing as a dialog
 

--- a/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
+++ b/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
@@ -12,6 +12,11 @@
         <ApplicationIcon>PleasantUIIcon.ico</ApplicationIcon>
         <IncludeAvaloniaGenerators>true</IncludeAvaloniaGenerators>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+        <DebugType>embedded</DebugType>
+        <IncludeSymbolsInSingleFile>true</IncludeSymbolsInSingleFile>
+    </PropertyGroup>
     
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="12.0.0" />

--- a/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
+++ b/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
@@ -16,13 +16,25 @@
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
         <DebugType>embedded</DebugType>
         <IncludeSymbolsInSingleFile>true</IncludeSymbolsInSingleFile>
+        <DefineConstants>$(DefineConstants);ENABLE_XAML_HOT_RELOAD</DefineConstants>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <LibrarySourcePath>$(MSBuildProjectDirectory)\..\..\src\PleasantUI</LibrarySourcePath>
+    </PropertyGroup>
+    <ItemGroup>
+        <!-- Передаем путь как константу компиляции -->
+        <CompilerVisibleProperty Include="LibrarySourcePath" />
+    </ItemGroup>
     
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="12.0.0" />
         <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
         <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="9.0.8" />
+        <PackageReference Include="HotAvalonia" Version="3.*" PrivateAssets="All" Publish="True" />
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="*" PrivateAssets="All" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.0.0" PrivateAssets="All" />
     </ItemGroup>
     
     <ItemGroup>

--- a/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
+++ b/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
@@ -13,20 +13,6 @@
         <IncludeAvaloniaGenerators>true</IncludeAvaloniaGenerators>
     </PropertyGroup>
     
-    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-        <DebugType>embedded</DebugType>
-        <IncludeSymbolsInSingleFile>true</IncludeSymbolsInSingleFile>
-        <DefineConstants>$(DefineConstants);ENABLE_XAML_HOT_RELOAD</DefineConstants>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <LibrarySourcePath>$(MSBuildProjectDirectory)\..\..\src\PleasantUI</LibrarySourcePath>
-    </PropertyGroup>
-    <ItemGroup>
-        <!-- Передаем путь как константу компиляции -->
-        <CompilerVisibleProperty Include="LibrarySourcePath" />
-    </ItemGroup>
-    
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="12.0.0" />
         <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />

--- a/samples/PleasantUI.Example/Factories/ControlPageCardsFactory.cs
+++ b/samples/PleasantUI.Example/Factories/ControlPageCardsFactory.cs
@@ -18,16 +18,16 @@ public class ControlPageCardsFactory
     {
         return
         [
-            new("CardTitle/Button",       MaterialIcons.ButtonCursor,        "Card/Button",    new ButtonPage(),   _eventAggregator),
-            new("CardTitle/Checkbox",     MaterialIcons.CheckboxMarkedOutline,"Card/Checkbox",  new CheckBoxPage(), _eventAggregator),
-            new("CardTitle/Progress",     MaterialIcons.ProgressHelper,       "Card/Progress",  new ProgressPage(), _eventAggregator),
-            new("CardTitle/Calendar",     MaterialIcons.CalendarOutline,      "Card/Calendar",  new CalendarPage(), _eventAggregator),
-            new("CardTitle/Carousel",     MaterialIcons.ViewCarouselOutline,  "Card/Carousel",  new CarouselPage(), _eventAggregator),
-            new("CardTitle/ComboBox",     MaterialIcons.ExpandAllOutline,     "Card/ComboBox",  new ComboBoxPage(), _eventAggregator),
-            new("CardTitle/TextBox",      MaterialIcons.FormTextbox,          "Card/TextBox",   new TextBoxPage(),  _eventAggregator),
-            new("CardTitle/DataGrid",     MaterialIcons.Grid,                 "Card/DataGrid",  new DataGridPage(), _eventAggregator),
-            new("CardTitle/PinCode",      MaterialIcons.KeyboardOutline,       "Card/PinCode",   new PinCodePage(),  _eventAggregator),
-            new("CardTitle/SelectionList", MaterialIcons.ViewListOutline, "Card/SelectionList", new SelectionListPage(), _eventAggregator),
+            new("CardTitle/Button",       MaterialIcons.ButtonCursor,        "Card/Button", () =>  new ButtonPage(),   _eventAggregator),
+            new("CardTitle/Checkbox",     MaterialIcons.CheckboxMarkedOutline,"Card/Checkbox", () =>  new CheckBoxPage(), _eventAggregator),
+            new("CardTitle/Progress",     MaterialIcons.ProgressHelper,       "Card/Progress", () =>  new ProgressPage(), _eventAggregator),
+            new("CardTitle/Calendar",     MaterialIcons.CalendarOutline,      "Card/Calendar", () =>  new CalendarPage(), _eventAggregator),
+            new("CardTitle/Carousel",     MaterialIcons.ViewCarouselOutline,  "Card/Carousel", () =>  new CarouselPage(), _eventAggregator),
+            new("CardTitle/ComboBox",     MaterialIcons.ExpandAllOutline,     "Card/ComboBox", () =>  new ComboBoxPage(), _eventAggregator),
+            new("CardTitle/TextBox",      MaterialIcons.FormTextbox,          "Card/TextBox", () =>   new TextBoxPage(),  _eventAggregator),
+            new("CardTitle/DataGrid",     MaterialIcons.Grid,                 "Card/DataGrid", () =>  new DataGridPage(), _eventAggregator),
+            new("CardTitle/PinCode",      MaterialIcons.KeyboardOutline,       "Card/PinCode", () =>   new PinCodePage(),  _eventAggregator),
+            new("CardTitle/SelectionList", MaterialIcons.ViewListOutline, "Card/SelectionList", () => new SelectionListPage(), _eventAggregator),
         ];
     }
 
@@ -35,28 +35,28 @@ public class ControlPageCardsFactory
     {
         return
         [
-            new("CardTitle/PleasantSnackbar",    MaterialIcons.InformationOutline,    "Card/PleasantSnackbar",    new PleasantSnackbarPage(),    _eventAggregator),
-            new("CardTitle/InformationBlock",    MaterialIcons.InformationBoxOutline, "Card/InformationBlock",    new InformationBlockPage(),    _eventAggregator),
-            new("CardTitle/OptionsDisplayItem",  MaterialIcons.ViewListOutline,       "Card/OptionsDisplayItem",  new OptionsDisplayItemPage(),  _eventAggregator),
-            new("CardTitle/PleasantTabView",     MaterialIcons.Tab,                   "Card/PleasantTabView",     new PleasantTabViewPage(),     _eventAggregator),
-            new("CardTitle/PleasantMenu",        MaterialIcons.MenuOpen,              "Card/PleasantMenu",        new PleasantMenuPage(),        _eventAggregator),
-            new("CardTitle/Timeline",            MaterialIcons.TimelineOutline,       "Card/Timeline",            new TimelinePage(),            _eventAggregator),
-            new("CardTitle/InstallWizard",       MaterialIcons.WizardHat,             "Card/InstallWizard",       new InstallWizardPage(),       _eventAggregator),
-            new("CardTitle/PleasantDrawer",      MaterialIcons.DrawingBox,    "Card/PleasantDrawer",      new PleasantDrawerPage(),      _eventAggregator),
-            new("CardTitle/PopConfirm",          MaterialIcons.CheckboxMarkedCircle,  "Card/PopConfirm",          new PopConfirmPage(),          _eventAggregator),
-            new("CardTitle/PathPicker",          MaterialIcons.FolderOpenOutline,     "Card/PathPicker",          new PathPickerPage(),          _eventAggregator),
-            new("CardTitle/PleasantMiniWindow",  MaterialIcons.WindowMinimize,        "Card/PleasantMiniWindow",  new PleasantMiniWindowPage(),  _eventAggregator),
-            new("CardTitle/BreadcrumbBar",       MaterialIcons.PageNextOutline,        "Card/BreadcrumbBar",       new BreadcrumbBarPage(),       _eventAggregator),
-            new("CardTitle/CommandBar",          MaterialIcons.ViewGridOutline,        "Card/CommandBar",          new CommandBarPage(),          _eventAggregator),
-            new("CardTitle/DashboardCard",       MaterialIcons.ViewDashboardOutline,   "Card/DashboardCard",       new DashboardCardPage(),       _eventAggregator),
-            new("CardTitle/LogViewerPanel",      MaterialIcons.TextBoxOutline,         "Card/LogViewerPanel",      new LogViewerPanelPage(),      _eventAggregator),
-            new("CardTitle/TerminalPanel",       MaterialIcons.ConsoleLine,            "Card/TerminalPanel",       new TerminalPanelPage(),       _eventAggregator),
-            new("CardTitle/TreeViewPanel",       MaterialIcons.FileTreeOutline,        "Card/TreeViewPanel",       new TreeViewPanelPage(),       _eventAggregator),
-            new("CardTitle/ItemListPanel",       MaterialIcons.FormatListBulletedType, "Card/ItemListPanel",       new ItemListPanelPage(),       _eventAggregator),
-            new("CardTitle/StepDialog",          MaterialIcons.OrderNumericAscending,  "Card/StepDialog",          new StepDialogPage(),          _eventAggregator),
-            new("CardTitle/PropertyGrid",        MaterialIcons.TableColumnPlusAfter,   "Card/PropertyGrid",        new PropertyGridPage(),        _eventAggregator),
-            new("CardTitle/DownloadPanel",       MaterialIcons.DownloadOutline,        "Card/DownloadPanel",       new DownloadPanelPage(),       _eventAggregator),
-            new("CardTitle/CrashReportDialog",   MaterialIcons.BugOutline,             "Card/CrashReportDialog",   new CrashReportDialogPage(),   _eventAggregator),
+            new("CardTitle/PleasantSnackbar",    MaterialIcons.InformationOutline,    "Card/PleasantSnackbar", () =>    new PleasantSnackbarPage(),    _eventAggregator),
+            new("CardTitle/InformationBlock",    MaterialIcons.InformationBoxOutline, "Card/InformationBlock", () =>    new InformationBlockPage(),    _eventAggregator),
+            new("CardTitle/OptionsDisplayItem",  MaterialIcons.ViewListOutline,       "Card/OptionsDisplayItem", () =>  new OptionsDisplayItemPage(),  _eventAggregator),
+            new("CardTitle/PleasantTabView",     MaterialIcons.Tab,                   "Card/PleasantTabView", () =>     new PleasantTabViewPage(),     _eventAggregator),
+            new("CardTitle/PleasantMenu",        MaterialIcons.MenuOpen,              "Card/PleasantMenu", () =>        new PleasantMenuPage(),        _eventAggregator),
+            new("CardTitle/Timeline",            MaterialIcons.TimelineOutline,       "Card/Timeline", () =>            new TimelinePage(),            _eventAggregator),
+            new("CardTitle/InstallWizard",       MaterialIcons.WizardHat,             "Card/InstallWizard", () =>       new InstallWizardPage(),       _eventAggregator),
+            new("CardTitle/PleasantDrawer",      MaterialIcons.DrawingBox,    "Card/PleasantDrawer", () =>      new PleasantDrawerPage(),      _eventAggregator),
+            new("CardTitle/PopConfirm",          MaterialIcons.CheckboxMarkedCircle,  "Card/PopConfirm", () =>          new PopConfirmPage(),          _eventAggregator),
+            new("CardTitle/PathPicker",          MaterialIcons.FolderOpenOutline,     "Card/PathPicker", () =>          new PathPickerPage(),          _eventAggregator),
+            new("CardTitle/PleasantMiniWindow",  MaterialIcons.WindowMinimize,        "Card/PleasantMiniWindow", () =>  new PleasantMiniWindowPage(),  _eventAggregator),
+            new("CardTitle/BreadcrumbBar",       MaterialIcons.PageNextOutline,        "Card/BreadcrumbBar", () =>       new BreadcrumbBarPage(),       _eventAggregator),
+            new("CardTitle/CommandBar",          MaterialIcons.ViewGridOutline,        "Card/CommandBar", () =>          new CommandBarPage(),          _eventAggregator),
+            new("CardTitle/DashboardCard",       MaterialIcons.ViewDashboardOutline,   "Card/DashboardCard", () =>       new DashboardCardPage(),       _eventAggregator),
+            new("CardTitle/LogViewerPanel",      MaterialIcons.TextBoxOutline,         "Card/LogViewerPanel", () =>      new LogViewerPanelPage(),      _eventAggregator),
+            new("CardTitle/TerminalPanel",       MaterialIcons.ConsoleLine,            "Card/TerminalPanel", () =>       new TerminalPanelPage(),       _eventAggregator),
+            new("CardTitle/TreeViewPanel",       MaterialIcons.FileTreeOutline,        "Card/TreeViewPanel", () =>       new TreeViewPanelPage(),       _eventAggregator),
+            new("CardTitle/ItemListPanel",       MaterialIcons.FormatListBulletedType, "Card/ItemListPanel", () =>       new ItemListPanelPage(),       _eventAggregator),
+            new("CardTitle/StepDialog",          MaterialIcons.OrderNumericAscending,  "Card/StepDialog", () =>          new StepDialogPage(),          _eventAggregator),
+            new("CardTitle/PropertyGrid",        MaterialIcons.TableColumnPlusAfter,   "Card/PropertyGrid", () =>        new PropertyGridPage(),        _eventAggregator),
+            new("CardTitle/DownloadPanel",       MaterialIcons.DownloadOutline,        "Card/DownloadPanel", () =>       new DownloadPanelPage(),       _eventAggregator),
+            new("CardTitle/CrashReportDialog",   MaterialIcons.BugOutline,             "Card/CrashReportDialog", () =>   new CrashReportDialogPage(),   _eventAggregator),
         ];
     }
 
@@ -64,8 +64,8 @@ public class ControlPageCardsFactory
     {
         return
         [
-            new("CardTitle/MessageBox", MaterialIcons.MessageOutline, "Card/MessageBox", new MessageBoxPage(), _eventAggregator),
-            new("CardTitle/Docking",    MaterialIcons.ViewDashboardOutline, "Card/Docking", new DockingPage(), _eventAggregator),
+            new("CardTitle/MessageBox", MaterialIcons.MessageOutline, "Card/MessageBox", () => new MessageBoxPage(), _eventAggregator),
+            new("CardTitle/Docking",    MaterialIcons.ViewDashboardOutline, "Card/Docking", () => new DockingPage(), _eventAggregator),
         ];
     }
 }

--- a/samples/PleasantUI.Example/Models/ControlPageCard.cs
+++ b/samples/PleasantUI.Example/Models/ControlPageCard.cs
@@ -19,7 +19,7 @@ public class ControlPageCard : INotifyPropertyChanged
     public string TitleKey { get; }
     public string DescriptionKey { get; }
     public Geometry Icon { get; set; }
-    public IPage Page { get; set; }
+    public Func<IPage> Page { get; set; }
 
     public string Title
     {
@@ -43,7 +43,7 @@ public class ControlPageCard : INotifyPropertyChanged
         }
     }
 
-    public ControlPageCard(string titleKey, Geometry icon, string descriptionKey, IPage page, IEventAggregator eventAggregator)
+    public ControlPageCard(string titleKey, Geometry icon, string descriptionKey, Func<IPage> page, IEventAggregator eventAggregator)
     {
         _eventAggregator = eventAggregator;
         TitleKey = titleKey;
@@ -79,5 +79,5 @@ public class ControlPageCard : INotifyPropertyChanged
         Localizer.Instance.TryGetString(key, out string value) ? value : key;
 
     public void OpenPage() =>
-        _eventAggregator.PublishAsync(new ChangePageMessage(Page));
+        _eventAggregator.PublishAsync(new ChangePageMessage(Page.Invoke()));
 }

--- a/samples/PleasantUI.Example/PleasantUI.Example.csproj
+++ b/samples/PleasantUI.Example/PleasantUI.Example.csproj
@@ -23,6 +23,9 @@
     <ItemGroup>
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
         <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="HotAvalonia" Version="3.*" PrivateAssets="All" Publish="True" />
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="*" PrivateAssets="All" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.0.0" PrivateAssets="All" />
     </ItemGroup>
     
     <ItemGroup>

--- a/samples/PleasantUI.Example/Properties/Localizations/App.resx
+++ b/samples/PleasantUI.Example/Properties/Localizations/App.resx
@@ -648,7 +648,7 @@ The above copyright notice and this permission notice shall be included in all c
     <data name="MiniWindow/PropsTitle"          xml:space="preserve"><value>Key properties</value></data>
     <data name="MiniWindow/PropEnableCustomTitleBar" xml:space="preserve"><value>Shows the custom drag handle and caption buttons instead of the OS title bar.</value></data>
     <data name="MiniWindow/PropShowPinButton"   xml:space="preserve"><value>Shows a pin button that toggles always-on-top (Topmost).</value></data>
-    <data name="MiniWindow/PropShowHiddenButton" xml:space="preserve"><value>Shows a minimize button that collapses the window to the taskbar.</value></data>
+    <data name="MiniWindow/PropShowMinimizeButton" xml:space="preserve"><value>Shows a minimize button that collapses the window to the taskbar.</value></data>
     <data name="MiniWindow/PropEnableBlur"      xml:space="preserve"><value>Enables acrylic/blur transparency behind the window background.</value></data>
 
     <!-- StepDialog page -->

--- a/samples/PleasantUI.Example/Properties/Localizations/App.ru.resx
+++ b/samples/PleasantUI.Example/Properties/Localizations/App.ru.resx
@@ -620,7 +620,7 @@
     <data name="MiniWindow/PropsTitle"          xml:space="preserve"><value>Ключевые свойства</value></data>
     <data name="MiniWindow/PropEnableCustomTitleBar" xml:space="preserve"><value>Показывает настраиваемую ручку перетаскивания и кнопки заголовка вместо системной строки заголовка.</value></data>
     <data name="MiniWindow/PropShowPinButton"   xml:space="preserve"><value>Показывает кнопку закрепления, переключающую режим «поверх всех окон» (Topmost).</value></data>
-    <data name="MiniWindow/PropShowHiddenButton" xml:space="preserve"><value>Показывает кнопку сворачивания, скрывающую окно на панель задач.</value></data>
+    <data name="MiniWindow/PropShowMinimizeButton" xml:space="preserve"><value>Показывает кнопку сворачивания, скрывающую окно на панель задач.</value></data>
     <data name="MiniWindow/PropEnableBlur"      xml:space="preserve"><value>Включает акриловое/размытое прозрачное фоновое покрытие окна.</value></data>
 
     <!-- StepDialog page -->

--- a/samples/PleasantUI.Example/Views/Pages/PleasantControlPages/PleasantMiniWindowPageView.axaml
+++ b/samples/PleasantUI.Example/Views/Pages/PleasantControlPages/PleasantMiniWindowPageView.axaml
@@ -44,8 +44,8 @@
                         <TextBlock Grid.Row="0" Grid.Column="2" Text="{Localize MiniWindow/PropEnableCustomTitleBar}" TextWrapping="Wrap" FontSize="12" Foreground="{DynamicResource TextFillColor2}" />
                         <TextBlock Grid.Row="1" Grid.Column="0" Text="ShowPinButton" FontFamily="Consolas,Monospace" FontSize="12" Foreground="{DynamicResource AccentFillColor1}" VerticalAlignment="Center" Margin="0 6 0 0" />
                         <TextBlock Grid.Row="1" Grid.Column="2" Text="{Localize MiniWindow/PropShowPinButton}" TextWrapping="Wrap" FontSize="12" Foreground="{DynamicResource TextFillColor2}" Margin="0 6 0 0" />
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="ShowHiddenButton" FontFamily="Consolas,Monospace" FontSize="12" Foreground="{DynamicResource AccentFillColor1}" VerticalAlignment="Center" Margin="0 6 0 0" />
-                        <TextBlock Grid.Row="2" Grid.Column="2" Text="{Localize MiniWindow/PropShowHiddenButton}" TextWrapping="Wrap" FontSize="12" Foreground="{DynamicResource TextFillColor2}" Margin="0 6 0 0" />
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="ShowMinimizeButton" FontFamily="Consolas,Monospace" FontSize="12" Foreground="{DynamicResource AccentFillColor1}" VerticalAlignment="Center" Margin="0 6 0 0" />
+                        <TextBlock Grid.Row="2" Grid.Column="2" Text="{Localize MiniWindow/PropShowMinimizeButton}" TextWrapping="Wrap" FontSize="12" Foreground="{DynamicResource TextFillColor2}" Margin="0 6 0 0" />
                         <TextBlock Grid.Row="3" Grid.Column="0" Text="EnableBlur" FontFamily="Consolas,Monospace" FontSize="12" Foreground="{DynamicResource AccentFillColor1}" VerticalAlignment="Center" Margin="0 6 0 0" />
                         <TextBlock Grid.Row="3" Grid.Column="2" Text="{Localize MiniWindow/PropEnableBlur}" TextWrapping="Wrap" FontSize="12" Foreground="{DynamicResource TextFillColor2}" Margin="0 6 0 0" />
                     </Grid>

--- a/samples/PleasantUI.Example/Views/Pages/PleasantControlPages/PleasantMiniWindowPageView.axaml.cs
+++ b/samples/PleasantUI.Example/Views/Pages/PleasantControlPages/PleasantMiniWindowPageView.axaml.cs
@@ -35,10 +35,12 @@ public partial class PleasantMiniWindowPageView : LocalizedUserControl
     {
         var steamWindow = new PleasantMiniWindow
         {
-            Title            = "Steam",
-            Width            = 460,
-            Height           = 340,
-            ShowHiddenButton = true,
+            Title              = "Steam",
+            Width              = 460,
+            Height             = 340,
+            ShowPinButton      = true,
+            ShowMinimizeButton = true,
+            ShowCloseButton    = true,
         };
 
         // Nav items: (label, description, opens games list)

--- a/src/PleasantUI/Controls/PleasantMiniWindow/PleasantMiniWindow.cs
+++ b/src/PleasantUI/Controls/PleasantMiniWindow/PleasantMiniWindow.cs
@@ -15,20 +15,20 @@ public class PleasantMiniWindow : PleasantWindowBase
     private Button? _closeButton;
     private Panel? _dragWindowPanel;
 
-    private Button? _hiddenButton;
+    private Button? _minimizeButton;
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
 
         _closeButton = e.NameScope.Find<Button>("PART_CloseButton");
-        _hiddenButton = e.NameScope.Find<Button>("PART_HiddenButton");
+        _minimizeButton = e.NameScope.Find<Button>("PART_MinimizeButton");
         _dragWindowPanel = e.NameScope.Find<Panel>("PART_DragWindow");
 
         if (_closeButton is not null)
             _closeButton.Click += (_, _) => Close();
-        if (_hiddenButton is not null)
-            _hiddenButton.Click += (_, _) => WindowState = WindowState.Minimized;
+        if (_minimizeButton is not null)
+            _minimizeButton.Click += (_, _) => WindowState = WindowState.Minimized;
 
         ExtendClientAreaToDecorationsHint = PleasantSettings.Current?.WindowSettings.EnableCustomTitleBar ?? false;
 
@@ -52,10 +52,16 @@ public class PleasantMiniWindow : PleasantWindowBase
         AvaloniaProperty.Register<PleasantMiniWindow, bool>(nameof(ShowPinButton), true);
 
     /// <summary>
-    /// Defines the <see cref="ShowHiddenButton"/> property.
+    /// Defines the <see cref="ShowMinimizeButton"/> property.
     /// </summary>
-    public static readonly StyledProperty<bool> ShowHiddenButtonProperty =
-        AvaloniaProperty.Register<PleasantMiniWindow, bool>(nameof(ShowHiddenButton));
+    public static readonly StyledProperty<bool> ShowMinimizeButtonProperty =
+        AvaloniaProperty.Register<PleasantMiniWindow, bool>(nameof(ShowMinimizeButton));
+
+    /// <summary>
+    /// Defines the <see cref="ShowCloseButton"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowCloseButtonProperty =
+        AvaloniaProperty.Register<PleasantMiniWindow, bool>(nameof(ShowCloseButton));
 
     /// <summary>
     /// Defines the <see cref="EnableCustomTitleBar"/> property.
@@ -91,10 +97,19 @@ public class PleasantMiniWindow : PleasantWindowBase
     /// <summary>
     /// Shows a spear that allows you to hide the window.
     /// </summary>
-    public bool ShowHiddenButton
+    public bool ShowMinimizeButton
     {
-        get => GetValue(ShowHiddenButtonProperty);
-        set => SetValue(ShowHiddenButtonProperty, value);
+        get => GetValue(ShowMinimizeButtonProperty);
+        set => SetValue(ShowMinimizeButtonProperty, value);
+    }
+
+    /// <summary>
+    /// Shows a button that allows you to close the window.
+    /// </summary>
+    public bool ShowCloseButton
+    {
+        get => GetValue(ShowCloseButtonProperty);
+        set => SetValue(ShowCloseButtonProperty, value);
     }
 
     /// <summary>

--- a/src/PleasantUI/Controls/PleasantMiniWindow/PleasantMiniWindow.cs
+++ b/src/PleasantUI/Controls/PleasantMiniWindow/PleasantMiniWindow.cs
@@ -55,13 +55,13 @@ public class PleasantMiniWindow : PleasantWindowBase
     /// Defines the <see cref="ShowMinimizeButton"/> property.
     /// </summary>
     public static readonly StyledProperty<bool> ShowMinimizeButtonProperty =
-        AvaloniaProperty.Register<PleasantMiniWindow, bool>(nameof(ShowMinimizeButton));
+        AvaloniaProperty.Register<PleasantMiniWindow, bool>(nameof(ShowMinimizeButton), false);
 
     /// <summary>
     /// Defines the <see cref="ShowCloseButton"/> property.
     /// </summary>
     public static readonly StyledProperty<bool> ShowCloseButtonProperty =
-        AvaloniaProperty.Register<PleasantMiniWindow, bool>(nameof(ShowCloseButton));
+        AvaloniaProperty.Register<PleasantMiniWindow, bool>(nameof(ShowCloseButton), true);
 
     /// <summary>
     /// Defines the <see cref="EnableCustomTitleBar"/> property.

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/PleasantMiniWindow.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/PleasantMiniWindow.axaml
@@ -39,10 +39,12 @@
                                               Margin="4"
                                               Theme="{DynamicResource AppBarToggleButtonTheme}"
                                               IsChecked="{CompiledBinding $parent[PleasantMiniWindow].Topmost}"
+                                              IsVisible="{TemplateBinding ShowPinButton}"
                                               ToolTip.Tip="{DynamicResource FastenOverTheWindows}">
                                     <Viewbox Width="10" Height="10">
                                         <Path Data="{DynamicResource PinRegular}"
-                                              StrokeThickness="2" />
+                                              StrokeThickness="2"
+                                              Stroke="{Binding $parent[PleasantMiniWindow].Foreground}" />
                                     </Viewbox>
                                 </ToggleButton>
 
@@ -59,19 +61,24 @@
                                             Orientation="Horizontal"
                                             Margin="4"
                                             IsVisible="{CompiledBinding $parent[PleasantMiniWindow].EnableCustomTitleBar}">
-                                    <Button x:Name="PART_HiddenButton"
+                                    <Button x:Name="PART_MinimizeButton"
                                             Theme="{DynamicResource AppBarButtonTheme}"
+                                            IsVisible="{TemplateBinding ShowMinimizeButton}"
                                             ToolTip.Tip="{DynamicResource Collapse}">
                                         <Viewbox Width="10" Height="10">
                                             <Path Data="{DynamicResource SubtractRegular}"
-                                                  StrokeThickness="2" />
+                                                  StrokeThickness="2"
+                                                  Stroke="{Binding $parent[PleasantMiniWindow].Foreground}" />
                                         </Viewbox>
                                     </Button>
                                     <Button x:Name="PART_CloseButton"
                                             Theme="{DynamicResource AppBarButtonTheme}"
+                                            IsVisible="{TemplateBinding ShowCloseButton}"
                                             ToolTip.Tip="{DynamicResource Close}">
                                         <Viewbox Width="8" Height="8">
-                                            <Path Data="{DynamicResource DismissRegular}" />
+                                            <Path Data="{DynamicResource DismissRegular}"
+                                                  StrokeThickness="2"
+                                                  Stroke="{Binding $parent[PleasantMiniWindow].Foreground}" />
                                         </Viewbox>
                                     </Button>
                                 </StackPanel>


### PR DESCRIPTION
The `PleasantMiniWindow` title bar buttons weren't displaying or hiding correctly due to incorrect bindings. This fixes the bindings.

I've also introduced a `ShowCloseButton` property, and added it to the docs.

And I've renamed `ShowHiddenButton` to `ShowMinimizeButton`, which is also reflected in the docs.

