### PR TITLE
Fixing bugs and problems

### DIFF
--- a/build/Package.props
+++ b/build/Package.props
@@ -4,14 +4,14 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
-        <PackageVersion>5.3.0</PackageVersion>
+        <PackageVersion>5.3.1</PackageVersion>
         <Authors>Dmitry Zhutkov (Onebeld), Andrey Savich (pieckenst)</Authors>
         <Copyright>Dmitry Zhutkov (Onebeld)</Copyright>
         <PackageTags>theme, design, xaml, library, ui, gui, control, csharp, styled-components, interface, dotnet, nuget, style, avalonia, controls, user-interface, styles, avaloniaui, pleasant, graphical-user-interface</PackageTags>
         <PackageDescription>PleasantUI is a cross-platform UI theme and control library for Avalonia, inspired by Microsoft Fluent Design and the WinUI/UWP visual language. It provides complete re-styled themes for all standard Avalonia controls — buttons, checkboxes, sliders, text boxes, data grids, calendars, combo boxes, and more — along with a suite of custom Pleasant controls including NavigationView, PleasantTabView, ProgressRing, OptionsDisplayItem, PleasantSnackbar, InformationBlock, ContentDialog, and a full theme editor with custom theme support. Supports light, dark, and multiple accent color themes out of the box, with a reactive localization system and desktop/mobile adaptive layouts.</PackageDescription>
         <Company>Onebeld</Company>
-        <AssemblyVersion>5.3.0.0</AssemblyVersion>
-        <FileVersion>5.3.0.0</FileVersion>
+        <AssemblyVersion>5.3.1.0</AssemblyVersion>
+        <FileVersion>5.3.1.0</FileVersion>
         <InformationalVersion>$(PackageVersion)</InformationalVersion>
         <IncludeAvaloniaGenerators>true</IncludeAvaloniaGenerators>
         <RepositoryUrl>https://github.com/Onebeld/PleasantUI</RepositoryUrl>
@@ -26,12 +26,6 @@
 
         <PackageProjectUrl>https://github.com/Onebeld/PleasantUI</PackageProjectUrl>
     </PropertyGroup>
-    
-    <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-        <PackageReference Include="HotAvalonia" Version="3.1.3" PrivateAssets="All" Publish="True" />
-        <PackageReference Include="MonoMod.RuntimeDetour" Version="*" PrivateAssets="All" />
-        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.1.0" PrivateAssets="All" />
-    </ItemGroup>
     
     <ItemGroup>
         <AdditionalFiles Include="**\*.axaml"/>

--- a/samples/PleasantUI.Example.Desktop/App.axaml
+++ b/samples/PleasantUI.Example.Desktop/App.axaml
@@ -22,8 +22,8 @@
         <dataTemplates:IconTemplateSelector x:Key="IconTemplateSelector">
             <DataTemplate x:Key="MaterialIcon" DataType="icons:MaterialIconKind">
                 <avalonia:MaterialIcon Kind="{Binding}"
-                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=PleasantIcon}}"
-                                       FontSize="{Binding (IconHelper.IconSize), RelativeSource={RelativeSource AncestorType=PleasantIcon}}" />
+                                       Foreground="{Binding $parent[PleasantIcon].Foreground}"
+                                       FontSize="{Binding $parent[PleasantIcon].(IconHelper.IconSize)}" />
             </DataTemplate>
         </dataTemplates:IconTemplateSelector>
     </Application.Resources>

--- a/samples/PleasantUI.Example.Desktop/App.axaml.cs
+++ b/samples/PleasantUI.Example.Desktop/App.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using PleasantUI.Controls;
+using Serilog;
 
 namespace PleasantUI.Example.Desktop;
 
@@ -21,6 +22,11 @@ public class App : PleasantUiExampleApp
     {
         if (ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
             return;
+
+        Avalonia.Threading.Dispatcher.UIThread.UnhandledException += (sender, args) =>
+        {
+            Log.Error(args.Exception, "Unhandled UI exception");
+        };
         
         if (Design.IsDesignMode)
         {

--- a/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
+++ b/samples/PleasantUI.Example.Desktop/PleasantUI.Example.Desktop.csproj
@@ -19,15 +19,13 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.1.0" />
-        <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
+        <PackageReference Include="Avalonia" Version="12.1.1" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.1.1" />
     </ItemGroup>
     
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
         <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
-        <PackageReference Include="HotAvalonia" Version="3.1.3" PrivateAssets="All" Publish="True" />
-        <PackageReference Include="MonoMod.RuntimeDetour" Version="*" PrivateAssets="All" />
-        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.1.0" PrivateAssets="All" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.1.1" PrivateAssets="All" />
     </ItemGroup>
     
     <ItemGroup>

--- a/samples/PleasantUI.Example.Desktop/Program.cs
+++ b/samples/PleasantUI.Example.Desktop/Program.cs
@@ -1,7 +1,10 @@
 ﻿using System.Text;
 using Avalonia;
+using Avalonia.Logging;
 using PleasantUI.Example.Logging.Logging;
 using Serilog;
+using Serilog.Templates;
+using Serilog.Templates.Themes;
 
 namespace PleasantUI.Example.Desktop;
 
@@ -19,8 +22,19 @@ class Program
         
         bool createLogFile = !File.Exists(FileName);
         
+        var expressionTemplate = new ExpressionTemplate(
+            "[{@t:HH:mm:ss} {@l}]" +
+            "{#if Area is not null} [{Area}]{#end}" +
+            "{#if @p.SourceContext is not null} ({@p.SourceContext}){#end}" +
+            " {@m}\n" +
+            "{@x}",
+            theme: TemplateTheme.Code
+        );
+        
         using PleasantLogger logger = new(
-            new LoggerConfiguration().WriteTo.File(FileName, outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz}] [{Level}] | {Message:lj}{NewLine}{Exception}")
+            new LoggerConfiguration()
+                .WriteTo.File(FileName, outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz}] [{Level}] | {Message:lj}{NewLine}{Exception}")
+                .WriteTo.Console(expressionTemplate)
         );
         
         if (createLogFile)
@@ -61,7 +75,12 @@ class Program
                 OverlayPopups = true
             });
 
-        appBuilder.LogToSerilog();
+        appBuilder.LogToSerilog(LogEventLevel.Debug, LogArea.Binding,
+            LogArea.Property,
+            LogArea.Animations,
+            LogArea.Control,
+            LogArea.Fonts,
+            LogArea.Platform);
 
         return appBuilder;
     }

--- a/samples/PleasantUI.Example/Logging/Logging/PleasantLogger.cs
+++ b/samples/PleasantUI.Example/Logging/Logging/PleasantLogger.cs
@@ -19,8 +19,14 @@ public class PleasantLogger : IDisposable
         
         AppDomain.CurrentDomain.FirstChanceException += CurrentDomainOnFirstChanceException;
         AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledException;
+        TaskScheduler.UnobservedTaskException += TaskSchedulerOnUnobservedTaskException;
         
         Log.Information("The logger has been initialized");
+    }
+
+    private void TaskSchedulerOnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+    {
+        Log.Error(e.Exception, "An unhandled exception occurred in task");
     }
 
     /// <inheritdoc/>
@@ -36,6 +42,9 @@ public class PleasantLogger : IDisposable
     
     private static void CurrentDomainOnFirstChanceException(object? sender, FirstChanceExceptionEventArgs e)
     {
+        if (e.Exception is TaskCanceledException)
+            return;
+        
         StackTrace stackTrace = new(1, true);
         Log.Error($"An handled exception occurred\n{e.Exception.GetType()}: {e.Exception.Message}\n{stackTrace}");
     }

--- a/samples/PleasantUI.Example/PleasantUI.Example.csproj
+++ b/samples/PleasantUI.Example/PleasantUI.Example.csproj
@@ -36,14 +36,14 @@
     <ItemGroup>
         <PackageReference Include="Material.Icons.Avalonia" Version="3.0.2" />
         <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
+        <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
         <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-        <PackageReference Include="HotAvalonia" Version="3.1.3" PrivateAssets="All" Publish="True" />
-        <PackageReference Include="MonoMod.RuntimeDetour" Version="*" PrivateAssets="All" />
-        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.1.0" PrivateAssets="All" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.1.1" PrivateAssets="All" />
     </ItemGroup>
     
     <ItemGroup>

--- a/samples/PleasantUI.Example/Views/AboutView.axaml
+++ b/samples/PleasantUI.Example/Views/AboutView.axaml
@@ -36,7 +36,7 @@
                     <!-- Author -->
                     <StackPanel Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right">
                         <PathIcon Data="{StaticResource Onebeld}"
-                                  Width="120"
+                                  Width="180"
                                   Height="NaN"
                                   HorizontalAlignment="Right" />
                         <TextBlock Text="Dmitry Zhutkov"

--- a/samples/PleasantUI.Example/Views/Pages/PleasantControlPages/PropertyGridPageView.axaml
+++ b/samples/PleasantUI.Example/Views/Pages/PleasantControlPages/PropertyGridPageView.axaml
@@ -15,7 +15,7 @@
             <StackPanel Spacing="12">
                 <TextBlock Text="{Localize PropertyGrid/DownloadTitle}"
                            Theme="{StaticResource BodyStrongTextBlockTheme}" />
-                <controls:PropertyGrid RowSpacing="10">
+                <controls:PropertyGrid Grid.IsSharedSizeScope="True" RowSpacing="10">
                     <controls:PropertyRow Label="{Localize PropertyGrid/LabelUrl}"
                                           Value="https://example.com/release/v2.1.0/setup.exe"
                                           ValueKind="Link"
@@ -42,7 +42,7 @@
             <StackPanel Spacing="12">
                 <TextBlock Text="{Localize PropertyGrid/ExceptionTitle}"
                            Theme="{StaticResource BodyStrongTextBlockTheme}" />
-                <controls:PropertyGrid RowSpacing="10">
+                <controls:PropertyGrid RowSpacing="10" ValueHorizontalAlignment="Right">
                     <controls:PropertyRow Label="{Localize PropertyGrid/LabelApplication}" Value="MyApp" />
                     <controls:PropertyRow Label="{Localize PropertyGrid/LabelVersion}" Value="2.1.0" />
                     <controls:PropertyRow Label="{Localize PropertyGrid/LabelOccurredAt}" Value="2025-04-09 14:32:01" />

--- a/src/PleasantUI.ToolKit/PleasantUI.ToolKit.csproj
+++ b/src/PleasantUI.ToolKit/PleasantUI.ToolKit.csproj
@@ -7,9 +7,9 @@
     <Import Project="..\..\build\Package.props" />
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.1.0" />
-        <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.1.0" />
-        <PackageReference Include="Avalonia.Skia" Version="12.1.0" />
+        <PackageReference Include="Avalonia" Version="12.1.1" />
+        <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.1.1" />
+        <PackageReference Include="Avalonia.Skia" Version="12.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PleasantUI.ToolKit/Styling/ControlThemes/PleasantDialogStyle.axaml
+++ b/src/PleasantUI.ToolKit/Styling/ControlThemes/PleasantDialogStyle.axaml
@@ -32,11 +32,6 @@
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
 
         <Setter Property="Template">
             <ControlTemplate>
@@ -46,6 +41,12 @@
                               BorderThickness="{TemplateBinding BorderThickness}"
                               CornerRadius="{TemplateBinding CornerRadius}"
                               Padding="{TemplateBinding Padding}">
+                    <RippleEffect.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </RippleEffect.Transitions>
+                    
                     <ContentPresenter x:Name="PART_ContentPresenter"
                                       Content="{TemplateBinding Content}"
                                       ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/src/PleasantUI.ToolKit/Styling/ControlThemes/PleasantToolKitControls/DownloadPanel.axaml
+++ b/src/PleasantUI.ToolKit/Styling/ControlThemes/PleasantToolKitControls/DownloadPanel.axaml
@@ -131,16 +131,18 @@
         <Setter Property="Padding" Value="14 6" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Cursor" Value="Hand" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
+        
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Background="{TemplateBinding Background}"
                         CornerRadius="{TemplateBinding CornerRadius}"
                         Padding="{TemplateBinding Padding}">
+                    <Border.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </Border.Transitions>
+                    
                     <ContentPresenter Content="{TemplateBinding Content}"
                                       HorizontalContentAlignment="Center"
                                       VerticalContentAlignment="Center"

--- a/src/PleasantUI/Controls/Chrome/PleasantTitleBar.cs
+++ b/src/PleasantUI/Controls/Chrome/PleasantTitleBar.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
+using Avalonia.Media.Imaging;
 using Avalonia.Reactive;
 using PleasantUI.Core.Internal.Reactive;
 using Path = Avalonia.Controls.Shapes.Path;
@@ -274,15 +275,30 @@ public class PleasantTitleBar : TemplatedControl
 
     private void SetDisplayIcon(object? obj)
     {
-        if (_displayIcon is null || obj is WindowIcon)
+        if (_host is null)
             return;
+        
+        if (_host.DisplayIcon is not null)
+            _displayIcon?.Icon = _host.DisplayIcon;
+        else if (_host.Icon is not null)
+        {
+            using MemoryStream stream = new();
+            _host.Icon.Save(stream);
+            stream.Position = 0;
 
-        _displayIcon.Icon = obj;
+            _displayIcon?.Icon = new Bitmap(stream);
+        }
     }
 
     private void SetDisplayTitle(object? obj)
     {
-        _displayTitle?.Icon = obj;
+        if (_host is null)
+            return;
+        
+        if (_host.DisplayTitle is not null)
+            _displayTitle?.Icon = _host.DisplayTitle;
+        else
+            _displayTitle?.Icon = _host.Title;
     }
 
     private void PopulateTitleBar()

--- a/src/PleasantUI/Controls/DashboardCard/DashboardCard.cs
+++ b/src/PleasantUI/Controls/DashboardCard/DashboardCard.cs
@@ -1,10 +1,8 @@
 using Avalonia;
-using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
-using Avalonia.Metadata;
 
 namespace PleasantUI.Controls;
 

--- a/src/PleasantUI/Controls/OptionsDisplayItem/OptionsDisplayItem.cs
+++ b/src/PleasantUI/Controls/OptionsDisplayItem/OptionsDisplayItem.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Metadata;
 
 namespace PleasantUI.Controls;
 
@@ -150,6 +151,7 @@ public class OptionsDisplayItem : TemplatedControl
     /// <value>
     /// The content of the property.
     /// </value>
+    [Content]
     public object? Content
     {
         get => GetValue(ContentProperty);

--- a/src/PleasantUI/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/PleasantUI/Controls/PropertyGrid/PropertyGrid.cs
@@ -1,9 +1,7 @@
-using System.Collections.Specialized;
 using Avalonia;
 using Avalonia.Collections;
-using Avalonia.Controls;
-using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Layout;
 using Avalonia.Metadata;
 
 namespace PleasantUI.Controls;
@@ -13,39 +11,23 @@ namespace PleasantUI.Controls;
 /// The left column shows labels and the right column shows values — which can be plain text,
 /// clickable links, colored status text, or arbitrary templated content.
 /// </summary>
-[TemplatePart(PART_RowsHost, typeof(ItemsControl))]
 public class PropertyGrid : TemplatedControl
 {
-    // ── Template part names ───────────────────────────────────────────────────
-
-    private const string PART_RowsHost = "PART_RowsHost";
-
-    // ── Styled properties ─────────────────────────────────────────────────────
-
-    /// <summary>Defines the <see cref="LabelColumnWidth"/> property.</summary>
-    public static readonly StyledProperty<GridLength> LabelColumnWidthProperty =
-        AvaloniaProperty.Register<PropertyGrid, GridLength>(nameof(LabelColumnWidth),
-            defaultValue: GridLength.Auto);
-
     /// <summary>Defines the <see cref="RowSpacing"/> property.</summary>
     public static readonly StyledProperty<double> RowSpacingProperty =
         AvaloniaProperty.Register<PropertyGrid, double>(nameof(RowSpacing), defaultValue: 10);
-
-    // ── Direct properties ─────────────────────────────────────────────────────
+    
+    /// <summary>Defines the <see cref="ValueHorizontalAlignment"/> property.</summary>
+    public static readonly StyledProperty<HorizontalAlignment> ValueHorizontalAlignmentProperty =
+        AvaloniaProperty.Register<PropertyGrid, HorizontalAlignment>(
+            nameof(ValueHorizontalAlignment),
+            defaultValue: HorizontalAlignment.Left,
+            inherits: true); // Наследуется дочерними элементами
 
     /// <summary>Defines the <see cref="Rows"/> direct property.</summary>
     public static readonly DirectProperty<PropertyGrid, AvaloniaList<PropertyRow>> RowsProperty =
         AvaloniaProperty.RegisterDirect<PropertyGrid, AvaloniaList<PropertyRow>>(
             nameof(Rows), o => o.Rows);
-
-    // ── CLR accessors ─────────────────────────────────────────────────────────
-
-    /// <summary>Gets or sets the width of the label column.</summary>
-    public GridLength LabelColumnWidth
-    {
-        get => GetValue(LabelColumnWidthProperty);
-        set => SetValue(LabelColumnWidthProperty, value);
-    }
 
     /// <summary>Gets or sets the vertical spacing between rows.</summary>
     public double RowSpacing
@@ -53,37 +35,15 @@ public class PropertyGrid : TemplatedControl
         get => GetValue(RowSpacingProperty);
         set => SetValue(RowSpacingProperty, value);
     }
+    
+    /// <summary>Gets or sets the horizontal alignment of the row values.</summary>
+    public HorizontalAlignment ValueHorizontalAlignment
+    {
+        get => GetValue(ValueHorizontalAlignmentProperty);
+        set => SetValue(ValueHorizontalAlignmentProperty, value);
+    }
 
     /// <summary>Gets the collection of property rows.</summary>
     [Content]
-    public AvaloniaList<PropertyRow> Rows { get; } = new();
-
-    // ── Private state ─────────────────────────────────────────────────────────
-
-    private ItemsControl? _rowsHost;
-
-    // ── Constructor ───────────────────────────────────────────────────────────
-
-    public PropertyGrid()
-    {
-        Rows.CollectionChanged += OnRowsChanged;
-    }
-
-    // ── Template ──────────────────────────────────────────────────────────────
-
-    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
-    {
-        base.OnApplyTemplate(e);
-
-        _rowsHost = e.NameScope.Find<ItemsControl>(PART_RowsHost);
-
-        _rowsHost?.ItemsSource = Rows;
-    }
-
-    // ── Private helpers ───────────────────────────────────────────────────────
-
-    private void OnRowsChanged(object? sender, NotifyCollectionChangedEventArgs e)
-    {
-        _rowsHost?.ItemsSource = Rows;
-    }
+    public AvaloniaList<PropertyRow> Rows { get; } = [];
 }

--- a/src/PleasantUI/Controls/PropertyGrid/PropertyRow.cs
+++ b/src/PleasantUI/Controls/PropertyGrid/PropertyRow.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
+using Avalonia.Layout;
 using Avalonia.Media;
 
 namespace PleasantUI.Controls;
@@ -15,10 +16,13 @@ public enum PropertyRowValueKind
 {
     /// <summary>Plain text label.</summary>
     Text,
+
     /// <summary>Clickable hyperlink-style button.</summary>
     Link,
+
     /// <summary>Colored status text (uses <see cref="PropertyRow.ValueBrush"/>).</summary>
     Status,
+
     /// <summary>Arbitrary content via <see cref="PropertyRow.ValueTemplate"/>.</summary>
     Custom
 }
@@ -29,13 +33,9 @@ public enum PropertyRowValueKind
 [PseudoClasses(PC_Link, PC_Status, PC_Custom)]
 public class PropertyRow : TemplatedControl
 {
-    // ── Pseudo-class names ────────────────────────────────────────────────────
-
-    internal const string PC_Link   = ":link";
-    internal const string PC_Status = ":status";
-    internal const string PC_Custom = ":custom";
-
-    // ── Styled properties ─────────────────────────────────────────────────────
+    private const string PC_Link = ":link";
+    private const string PC_Status = ":status";
+    private const string PC_Custom = ":custom";
 
     /// <summary>Defines the <see cref="Label"/> property.</summary>
     public static readonly StyledProperty<string?> LabelProperty =
@@ -68,8 +68,10 @@ public class PropertyRow : TemplatedControl
     /// <summary>Defines the <see cref="ToolTipText"/> property.</summary>
     public static readonly StyledProperty<string?> ToolTipTextProperty =
         AvaloniaProperty.Register<PropertyRow, string?>(nameof(ToolTipText));
-
-    // ── CLR accessors ─────────────────────────────────────────────────────────
+    
+    /// <summary>Defines the <see cref="ValueHorizontalAlignment"/> property.</summary>
+    public static readonly StyledProperty<HorizontalAlignment> ValueHorizontalAlignmentProperty =
+        PropertyGrid.ValueHorizontalAlignmentProperty.AddOwner<PropertyRow>();
 
     /// <summary>Gets or sets the label shown in the left column.</summary>
     public string? Label
@@ -90,6 +92,13 @@ public class PropertyRow : TemplatedControl
     {
         get => GetValue(ValueTemplateProperty);
         set => SetValue(ValueTemplateProperty, value);
+    }
+    
+    /// <summary>Gets or sets the horizontal alignment of the row value.</summary>
+    public HorizontalAlignment ValueHorizontalAlignment
+    {
+        get => GetValue(ValueHorizontalAlignmentProperty);
+        set => SetValue(ValueHorizontalAlignmentProperty, value);
     }
 
     /// <summary>Gets or sets how the value is rendered.</summary>
@@ -127,8 +136,7 @@ public class PropertyRow : TemplatedControl
         set => SetValue(ToolTipTextProperty, value);
     }
 
-    // ── Overrides ─────────────────────────────────────────────────────────────
-
+    /// <inheritdoc/>
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
@@ -136,7 +144,8 @@ public class PropertyRow : TemplatedControl
         if (change.Property == ValueKindProperty)
         {
             PropertyRowValueKind kind = change.GetNewValue<PropertyRowValueKind>();
-            PseudoClasses.Set(PC_Link,   kind == PropertyRowValueKind.Link);
+
+            PseudoClasses.Set(PC_Link, kind == PropertyRowValueKind.Link);
             PseudoClasses.Set(PC_Status, kind == PropertyRowValueKind.Status);
             PseudoClasses.Set(PC_Custom, kind == PropertyRowValueKind.Custom);
         }

--- a/src/PleasantUI/Controls/Ripple/RippleEffect.cs
+++ b/src/PleasantUI/Controls/Ripple/RippleEffect.cs
@@ -13,7 +13,6 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Rendering.Composition;
-using Avalonia.Threading;
 
 namespace PleasantUI.Controls;
 
@@ -23,15 +22,14 @@ namespace PleasantUI.Controls;
 public class RippleEffect : ContentControl
 {
     private CompositionContainerVisual? _container;
-    private bool _isCancelled;
-    private CompositionCustomVisual? _last;
-    private byte _pointers;
+    private readonly List<CompositionCustomVisual> _activeRipples = new();
+    private CancellationTokenSource? _detachCts;
     
 	/// <summary>
 	/// Defines the <see cref="RippleFill" /> property.
 	/// </summary>
-	public static readonly StyledProperty<IBrush> RippleFillProperty =
-        AvaloniaProperty.Register<RippleEffect, IBrush>(nameof(RippleFill), inherits: true,
+	public static readonly StyledProperty<IBrush?> RippleFillProperty =
+        AvaloniaProperty.Register<RippleEffect, IBrush?>(nameof(RippleFill), inherits: true,
             defaultValue: Brushes.White);
 
 	/// <summary>
@@ -61,7 +59,7 @@ public class RippleEffect : ContentControl
     /// <summary>
     /// Gets or sets the brush used to fill the ripple.
     /// </summary>
-    public IBrush RippleFill
+    public IBrush? RippleFill
     {
         get => GetValue(RippleFillProperty);
         set => SetValue(RippleFillProperty, value);
@@ -124,6 +122,8 @@ public class RippleEffect : ContentControl
     {
         base.OnAttachedToVisualTree(e);
 
+        _detachCts = new CancellationTokenSource();
+
         CompositionVisual thisVisual = ElementComposition.GetElementVisual(this)!;
         _container = thisVisual.Compositor.CreateContainerVisual();
         _container.Size = new Vector(Bounds.Width, Bounds.Height);
@@ -134,6 +134,15 @@ public class RippleEffect : ContentControl
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
+        
+        _detachCts?.Cancel();
+        _detachCts?.Dispose();
+        _detachCts = null;
+        
+        _activeRipples.Clear();
+
+        if (_container is { } container)
+            container.Children.Clear();
 
         _container = null;
         ElementComposition.SetElementChildVisual(this, null);
@@ -160,68 +169,59 @@ public class RippleEffect : ContentControl
         (double x, double y) = e.GetPosition(this);
         if (_container is null || x < 0 || x > Bounds.Width || y < 0 || y > Bounds.Height) return;
 
-        _isCancelled = false;
-
         if (!IsAllowedRaiseRipple)
             return;
 
-        if (_pointers != 0)
-            return;
+        CompositionCustomVisual? r = CreateRipple(x, y, RaiseRippleCenter);
+        if (r is null) return;
 
-        // Only first pointer can arrive a ripple
-        _pointers++;
-        CompositionCustomVisual r = CreateRipple(x, y, RaiseRippleCenter);
-        _last = r;
-
-        // Attach ripple instance to canvas
+        _activeRipples.Add(r);
         _container.Children.Add(r);
         r.SendHandlerMessage(RippleHandler.FirstStepMessage);
-
-        if (_isCancelled) RemoveLastRipple();
     }
 
-    private void LostFocusHandler(object? sender, RoutedEventArgs e)
+    private void LostFocusHandler(object? sender, RoutedEventArgs e) => RemoveAllRipples();
+
+    private void PointerReleasedHandler(object? sender, PointerReleasedEventArgs e) => RemoveAllRipples();
+
+    private void PointerCaptureLostHandler(object? sender, PointerCaptureLostEventArgs e) => RemoveAllRipples();
+
+    private void RemoveAllRipples()
     {
-        _isCancelled = true;
-        RemoveLastRipple();
+        if (_activeRipples.Count == 0) return;
+
+        for (int i = _activeRipples.Count - 1; i >= 0; i--)
+        {
+            CompositionCustomVisual ripple = _activeRipples[i];
+            _ = OnReleaseHandlerAsync(ripple);
+        }
+    
+        _activeRipples.Clear();
     }
 
-    private void PointerReleasedHandler(object? sender, PointerReleasedEventArgs e)
-    {
-        _isCancelled = true;
-        RemoveLastRipple();
-    }
-
-    private void PointerCaptureLostHandler(object? sender, PointerCaptureLostEventArgs e)
-    {
-        _isCancelled = true;
-        RemoveLastRipple();
-    }
-
-    private void RemoveLastRipple()
-    {
-        if (_last == null)
-            return;
-
-        _pointers--;
-
-        // This way to handle pointer released is pretty tricky
-        // could have more better way to improve
-        OnReleaseHandler(_last);
-        _last = null;
-    }
-
-    private void OnReleaseHandler(CompositionCustomVisual r)
+    private async Task OnReleaseHandlerAsync(CompositionCustomVisual r)
     {
         // Fade out ripple
         r.SendHandlerMessage(RippleHandler.SecondStepMessage);
 
         // Remove ripple from canvas to finalize ripple instance
         CompositionContainerVisual? container = _container;
-        DispatcherTimer.RunOnce(() => { container?.Children.Remove(r); }, Ripple.Duration, DispatcherPriority.Render);
+        CancellationToken token = _detachCts?.Token ?? CancellationToken.None;
+
+        try
+        {
+            await Task.Delay(Ripple.Duration, token);
+
+            if (!token.IsCancellationRequested && container is not null)
+                container.Children.Remove(r);
+        }
+        catch (OperationCanceledException)
+        {
+            
+        }
     }
 
-    private CompositionCustomVisual CreateRipple(double x, double y, bool center)
+    private CompositionCustomVisual? CreateRipple(double x, double y, bool center)
     {
         double w = Bounds.Width;
         double h = Bounds.Height;
@@ -232,17 +232,23 @@ public class RippleEffect : ContentControl
             x = w / 2;
             y = h / 2;
         }
+        
+        IBrush fillBrush = RippleFill ?? Brushes.White;
+        IImmutableBrush immutableFill = fillBrush.ToImmutable();
 
         RippleHandler handler = new(
-            RippleFill.ToImmutable(),
+            immutableFill,
             Ripple.Easing,
             Ripple.Duration,
             RippleOpacity,
             CornerRadius,
             x, y, w, h, t);
 
-        CompositionCustomVisual visual =
-            ElementComposition.GetElementVisual(this)!.Compositor.CreateCustomVisual(handler);
+        CompositionVisual? elementVisual = ElementComposition.GetElementVisual(this);
+        if (elementVisual is null)
+            return null;
+        
+        CompositionCustomVisual visual = elementVisual.Compositor.CreateCustomVisual(handler);
         visual.Size = new Vector(Bounds.Width, Bounds.Height);
         return visual;
     }

--- a/src/PleasantUI/PleasantTheme.axaml.cs
+++ b/src/PleasantUI/PleasantTheme.axaml.cs
@@ -303,6 +303,9 @@ public class PleasantTheme : Styles
             case nameof(PleasantSettings.Current.AccentColor):
                 UpdateAccentColors(PleasantSettings.Current.AccentColor);
                 break;
+            case nameof(PleasantSettings.Current.Font):
+                Resources["GlobalFontFamily"] = PleasantSettings.Current.Font;
+                break;
         }
     }
 
@@ -332,6 +335,8 @@ public class PleasantTheme : Styles
     {
         if (PleasantSettings.Current is null)
             throw new NullReferenceException("PleasantSettings.Current is null.");
+        
+        Resources["GlobalFontFamily"] = PleasantSettings.Current.Font;
 
         ThemeVariant? themeVariant = PleasantSettings.Current.Theme switch
         {

--- a/src/PleasantUI/PleasantUI.csproj
+++ b/src/PleasantUI/PleasantUI.csproj
@@ -10,8 +10,8 @@
     <Import Project="..\..\build\Package.props" />
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.1.0" />
-        <PackageReference Include="Avalonia.Skia" Version="12.1.0" />
+        <PackageReference Include="Avalonia" Version="12.1.1" />
+        <PackageReference Include="Avalonia.Skia" Version="12.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/Button.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/Button.axaml
@@ -23,11 +23,6 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Background" Value="{DynamicResource ControlFillColor1}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColor1}" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions> 
-        </Setter>
 
         <Setter Property="Template">
             <ControlTemplate>
@@ -35,6 +30,12 @@
                               Background="{TemplateBinding Background}"
                               CornerRadius="{TemplateBinding CornerRadius}"
                               Padding="{TemplateBinding Padding}">
+                    <RippleEffect.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </RippleEffect.Transitions>
+                    
                     <ContentPresenter Name="PART_ContentPresenter"
                                       ContentTemplate="{TemplateBinding ContentTemplate}"
                                       Content="{TemplateBinding Content}"

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/ButtonSpinner.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/ButtonSpinner.axaml
@@ -37,11 +37,6 @@
         <Setter Property="Background" Value="{ColorToTransparent ControlFillColor1}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColor2}" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
 
         <Setter Property="Template">
             <ControlTemplate>
@@ -51,6 +46,12 @@
                               BorderThickness="{TemplateBinding BorderThickness}"
                               CornerRadius="{TemplateBinding CornerRadius}"
                               Padding="{TemplateBinding Padding}">
+                    <RippleEffect.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </RippleEffect.Transitions>
+                    
                     <ContentPresenter Name="PART_ContentPresenter"
                                       ContentTemplate="{TemplateBinding ContentTemplate}"
                                       Content="{TemplateBinding Content}"

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/CalendarButton.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/CalendarButton.axaml
@@ -19,28 +19,27 @@
         <Setter Property="Margin" Value="1" />
         <Setter Property="Width" Value="70" />
         <Setter Property="Height" Value="70" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
 
         <Setter Property="Template">
             <ControlTemplate>
-                <Panel>
-                    <Border Name="Root"
-                            Background="{TemplateBinding Background}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            BorderThickness="0"
-                            ClipToBounds="True">
-                        <ContentPresenter Name="Content"
-                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                          Content="{TemplateBinding Content}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          Margin="{TemplateBinding Padding}" />
-                    </Border>
-                </Panel>
+                <Border Name="Root"
+                        Background="{TemplateBinding Background}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        BorderThickness="0"
+                        ClipToBounds="True">
+                    <Border.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </Border.Transitions>
+                    
+                    <ContentPresenter Name="Content"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Content="{TemplateBinding Content}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      Margin="{TemplateBinding Padding}" />
+                </Border>
             </ControlTemplate>
         </Setter>
 

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/CalendarDatePicker.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/CalendarDatePicker.axaml
@@ -15,11 +15,6 @@
         <Setter Property="Margin" Value="0 1 1 1" />
         <Setter Property="Background" Value="{ColorToTransparent ControlFillColor2}" />
         <Setter Property="CornerRadius" Value="{DynamicResource RoundedControlCornerRadius}" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
 
         <Setter Property="Template">
             <ControlTemplate>
@@ -27,6 +22,12 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         CornerRadius="{TemplateBinding CornerRadius}"
                         Background="{TemplateBinding Background}">
+                    <Border.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </Border.Transitions>
+                    
                     <Grid Width="35"
                           Height="24"
                           HorizontalAlignment="Center"

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/CalendarItem.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/CalendarItem.axaml
@@ -23,12 +23,6 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Background" Value="{ColorToTransparent ControlFillColor2}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-        
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
 
         <Setter Property="Template">
             <ControlTemplate>
@@ -39,6 +33,12 @@
                               CornerRadius="{TemplateBinding CornerRadius}"
                               Margin="{TemplateBinding Margin}"
                               Padding="{TemplateBinding Padding}">
+                    <RippleEffect.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </RippleEffect.Transitions>
+                    
                     <ContentPresenter Name="Text" 
                                       Content="{TemplateBinding Content}"
                                       HorizontalContentAlignment="Stretch"

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/ComboBox.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/ComboBox.axaml
@@ -44,11 +44,6 @@
                 <VirtualizingStackPanel />
             </ItemsPanelTemplate>
         </Setter>
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
         
         <Setter Property="Template">
             <ControlTemplate>
@@ -68,7 +63,13 @@
                                       Grid.ColumnSpan="2"
                                       Background="{TemplateBinding Background}"
                                       CornerRadius="{TemplateBinding CornerRadius}"
-                                      MinWidth="64" />
+                                      MinWidth="64">
+                            <RippleEffect.Transitions>
+                                <Transitions>
+                                    <BrushTransition Property="Background" Duration="0:0:0.1" />
+                                </Transitions>
+                            </RippleEffect.Transitions>
+                        </RippleEffect>
 
                         <TextBlock x:Name="PlaceholderTextBlock"
                                    Grid.Row="1"

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/ComboBoxItem.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/ComboBoxItem.axaml
@@ -36,11 +36,6 @@
                 </Border>
             </FocusAdornerTemplate>
         </Setter>
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions> 
-        </Setter>
         
         <Setter Property="Template">
             <ControlTemplate>
@@ -51,6 +46,12 @@
                               Margin="5,2,5,2"
                               CornerRadius="{TemplateBinding CornerRadius}"
                               TemplatedControl.IsTemplateFocusTarget="True">
+                    <RippleEffect.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </RippleEffect.Transitions>
+                    
                     <Panel>
                         <Border Name="Pill" Theme="{StaticResource ComboBoxItemPillBorder}" />
 

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/DropDownButton.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/DropDownButton.axaml
@@ -20,11 +20,6 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions> 
-        </Setter>
 
         <Setter Property="Template">
             <ControlTemplate>
@@ -33,6 +28,12 @@
                               BorderBrush="{TemplateBinding BorderBrush}"
                               BorderThickness="{TemplateBinding BorderThickness}"
                               CornerRadius="{TemplateBinding CornerRadius}">
+                    <RippleEffect.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </RippleEffect.Transitions>
+                    
                     <DockPanel x:Name="InnerGrid">
                         <PleasantIcon x:Name="DropDownGlyph"
                                       DockPanel.Dock="Right"

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/Expander.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/Expander.axaml
@@ -53,11 +53,6 @@
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
 
         <Setter Property="Template">
             <ControlTemplate>
@@ -66,6 +61,12 @@
                               Background="{TemplateBinding Background}"
                               BorderBrush="{TemplateBinding BorderBrush}"
                               BorderThickness="{TemplateBinding BorderThickness}">
+                    <RippleEffect.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </RippleEffect.Transitions>
+                    
                     <DockPanel>
                         <Border x:Name="ExpandCollapseChevronBorder"
                                 DockPanel.Dock="Right"

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/ListBoxItem.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/ListBoxItem.axaml
@@ -38,30 +38,28 @@
         <Setter Property="(CompositionAnimationBehavior.UseEntranceAnimations)" Value="True" />
         <Setter Property="(CompositionAnimationBehavior.UseImplicitAnimations)" Value="True" />
         
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions> 
-        </Setter>
-        
         <Setter Property="Template">
             <ControlTemplate>
                 <Panel>
-                    <Border Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            Margin="2"
-                            ClipToBounds="True">
-                        <RippleEffect x:Name="PART_Ripple">
-                            <ContentPresenter Name="PART_ContentPresenter"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              Content="{TemplateBinding Content}"
-                                              Padding="{TemplateBinding Padding}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
-                        </RippleEffect>
-                    </Border>
+                    <RippleEffect x:Name="PART_Ripple"
+                                  Background="{TemplateBinding Background}"
+                                  BorderBrush="{TemplateBinding BorderBrush}"
+                                  BorderThickness="{TemplateBinding BorderThickness}"
+                                  CornerRadius="{TemplateBinding CornerRadius}"
+                                  Margin="2">
+                        <RippleEffect.Transitions>
+                            <Transitions>
+                                <BrushTransition Property="Background" Duration="0:0:0.1" />
+                            </Transitions>
+                        </RippleEffect.Transitions>
+
+                        <ContentPresenter Name="PART_ContentPresenter"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Content="{TemplateBinding Content}"
+                                          Padding="{TemplateBinding Padding}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
+                    </RippleEffect>
 
                     <Border Name="SelectionIndicator"
                             HorizontalAlignment="Left"
@@ -134,29 +132,28 @@
         <Setter Property="ClipToBounds" Value="False" />
         <Setter Property="(CompositionAnimationBehavior.UseEntranceAnimations)" Value="True" />
         <Setter Property="(CompositionAnimationBehavior.UseImplicitAnimations)" Value="True" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
         
         <Setter Property="Template">
             <ControlTemplate>
                 <Panel>
-                    <Border Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            ClipToBounds="True"
-                            CornerRadius="{TemplateBinding CornerRadius}">
-                        <RippleEffect x:Name="PART_Ripple">
-                            <ContentPresenter Name="PART_ContentPresenter"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              Content="{TemplateBinding Content}"
-                                              Padding="{TemplateBinding Padding}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
-                        </RippleEffect>
-                    </Border>
+                    <RippleEffect x:Name="PART_Ripple"
+                                  Background="{TemplateBinding Background}"
+                                  BorderBrush="{TemplateBinding BorderBrush}"
+                                  BorderThickness="{TemplateBinding BorderThickness}"
+                                  CornerRadius="{TemplateBinding CornerRadius}">
+                        <RippleEffect.Transitions>
+                            <Transitions>
+                                <BrushTransition Property="Background" Duration="0:0:0.1" />
+                            </Transitions>
+                        </RippleEffect.Transitions>
+                        
+                        <ContentPresenter Name="PART_ContentPresenter"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Content="{TemplateBinding Content}"
+                                          Padding="{TemplateBinding Padding}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
+                    </RippleEffect>
 
                     <Border Name="SelectionIndicator"
                             Background="{DynamicResource AccentLightColor2}"

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/Menu.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/Menu.axaml
@@ -7,58 +7,57 @@
         <Setter Property="Background" Value="{ColorToTransparent ControlFillColor2}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColor1}" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions> 
-        </Setter> 
-        
+
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Name="PART_LayoutRoot"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
-                    <RippleEffect x:Name="PART_Ripple">
-                        <Panel>
-                            <ContentPresenter Name="PART_HeaderPresenter"
-                                              Content="{TemplateBinding Header}"
-                                              VerticalAlignment="Center"
-                                              HorizontalAlignment="Stretch"
-                                              Margin="{TemplateBinding Padding}">
-                                <ContentPresenter.DataTemplates>
-                                    <DataTemplate DataType="system:String">
-                                        <AccessText Text="{CompiledBinding}" />
-                                    </DataTemplate>
-                                </ContentPresenter.DataTemplates>
-                            </ContentPresenter>
-                            <Popup Name="PART_Popup"
-                                   WindowManagerAddShadowHint="False"
-                                   MinWidth="{CompiledBinding $parent[TextBox].Bounds.Width}"
-                                   IsLightDismissEnabled="True"
-                                   IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
-                                   OverlayInputPassThroughElement="{CompiledBinding $parent[Menu]}">
-                                <ShadowBorder CornerRadius="{DynamicResource ControlCornerRadius}"
-                                              Background="{DynamicResource BackgroundColor1}"
-                                              HorizontalAlignment="Stretch"
-                                              MaxWidth="456"
-                                              MinHeight="32"
-                                              Margin="6 4 6 6"
-                                              BlurRadius="5"
-                                              Offset="0 1"
-                                              ShadowColor="#3C000000">
-                                    <ScrollViewer>
-                                        <ItemsPresenter Name="PART_ItemsPresenter"
-                                                        ItemsPanel="{TemplateBinding ItemsPanel}"
-                                                        Margin="0 2 0 2"
-                                                        Grid.IsSharedSizeScope="True" />
-                                    </ScrollViewer>
-                                </ShadowBorder>
-                            </Popup>
-                        </Panel>
-                    </RippleEffect>
-                </Border>
+                <RippleEffect x:Name="PART_Ripple"
+                              Background="{TemplateBinding Background}"
+                              BorderBrush="{TemplateBinding BorderBrush}"
+                              BorderThickness="{TemplateBinding BorderThickness}"
+                              CornerRadius="{TemplateBinding CornerRadius}">
+                    <RippleEffect.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </RippleEffect.Transitions>
+
+                    <Panel>
+                        <ContentPresenter Name="PART_HeaderPresenter"
+                                          Content="{TemplateBinding Header}"
+                                          VerticalAlignment="Center"
+                                          HorizontalAlignment="Stretch"
+                                          Margin="{TemplateBinding Padding}">
+                            <ContentPresenter.DataTemplates>
+                                <DataTemplate DataType="system:String">
+                                    <AccessText Text="{CompiledBinding}" />
+                                </DataTemplate>
+                            </ContentPresenter.DataTemplates>
+                        </ContentPresenter>
+                        <Popup Name="PART_Popup"
+                               WindowManagerAddShadowHint="False"
+                               MinWidth="{CompiledBinding $parent[TextBox].Bounds.Width}"
+                               IsLightDismissEnabled="True"
+                               IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
+                               OverlayInputPassThroughElement="{CompiledBinding $parent[Menu]}">
+                            <ShadowBorder CornerRadius="{DynamicResource ControlCornerRadius}"
+                                          Background="{DynamicResource BackgroundColor1}"
+                                          HorizontalAlignment="Stretch"
+                                          MaxWidth="456"
+                                          MinHeight="32"
+                                          Margin="6 4 6 6"
+                                          BlurRadius="5"
+                                          Offset="0 1"
+                                          ShadowColor="#3C000000">
+                                <ScrollViewer>
+                                    <ItemsPresenter Name="PART_ItemsPresenter"
+                                                    ItemsPanel="{TemplateBinding ItemsPanel}"
+                                                    Margin="0 2 0 2"
+                                                    Grid.IsSharedSizeScope="True" />
+                                </ScrollViewer>
+                            </ShadowBorder>
+                        </Popup>
+                    </Panel>
+                </RippleEffect>
             </ControlTemplate>
         </Setter>
 
@@ -66,12 +65,12 @@
             <Setter Property="RippleFill" Value="{DynamicResource ControlFillColor3}" />
         </Style>
 
-        <Style Selector="^:selected /template/ Border#PART_LayoutRoot">
+        <Style Selector="^:selected /template/ RippleEffect#PART_Ripple">
             <Setter Property="Background" Value="{DynamicResource ControlFillColor2}" />
         </Style>
 
         <!--  Listen for PART_LayoutRoot:pointerover, so it will not be triggered when subitem is pressed  -->
-        <Style Selector="^:pressed /template/ Border#PART_LayoutRoot">
+        <Style Selector="^:pressed /template/ RippleEffect#PART_Ripple">
             <Setter Property="Background" Value="{DynamicResource ControlFillColor2}" />
         </Style>
 

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/MenuItem.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/MenuItem.axaml
@@ -58,70 +58,70 @@
         <Setter Property="(IconHelper.Height)" Value="14" />
         <Setter Property="(IconHelper.FontSize)" Value="0" />
         <Setter Property="(IconHelper.IconSize)" Value="14" />
-        
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions> 
-        </Setter>
-        
+
         <Setter Property="Template">
             <ControlTemplate>
                 <Panel>
-                    <Border Name="PART_LayoutRoot"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            Margin="4 2"
-                            ClipToBounds="True">
-                        <RippleEffect x:Name="PART_Ripple" Padding="{TemplateBinding Padding}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIcon" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGT" />
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemChevron" />
-                                </Grid.ColumnDefinitions>
-                                <PleasantIcon Name="PART_IconPresenter"
-                                             Icon="{TemplateBinding Icon}"
-                                             Width="{TemplateBinding (IconHelper.Width)}"
-                                             Height="{TemplateBinding (IconHelper.Height)}"
-                                             IconHelper.FontSize="{TemplateBinding (IconHelper.FontSize)}"
-                                             IconHelper.IconSize="{TemplateBinding (IconHelper.IconSize)}"
-                                             Margin="0 0 12 0"
-                                             HorizontalAlignment="Center"
-                                             VerticalAlignment="Center" />
+                    <RippleEffect x:Name="PART_Ripple"
+                                  Padding="{TemplateBinding Padding}"
+                                  Background="{TemplateBinding Background}"
+                                  BorderBrush="{TemplateBinding BorderBrush}"
+                                  BorderThickness="{TemplateBinding BorderThickness}"
+                                  CornerRadius="{TemplateBinding CornerRadius}"
+                                  Margin="4 2">
+                        <RippleEffect.Transitions>
+                            <Transitions>
+                                <BrushTransition Property="Background" Duration="0:0:0.1" />
+                            </Transitions>
+                        </RippleEffect.Transitions>
+                        
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIcon" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGT" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemChevron" />
+                            </Grid.ColumnDefinitions>
+                            
+                            <PleasantIcon Name="PART_IconPresenter"
+                                          Icon="{TemplateBinding Icon}"
+                                          Width="{TemplateBinding (IconHelper.Width)}"
+                                          Height="{TemplateBinding (IconHelper.Height)}"
+                                          IconHelper.FontSize="{TemplateBinding (IconHelper.FontSize)}"
+                                          IconHelper.IconSize="{TemplateBinding (IconHelper.IconSize)}"
+                                          Margin="0 0 12 0"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
 
-                                <ContentPresenter Name="PART_HeaderPresenter"
-                                                  Content="{TemplateBinding Header}"
-                                                  VerticalAlignment="Center"
-                                                  HorizontalAlignment="Stretch"
-                                                  Grid.Column="1">
-                                    <ContentPresenter.DataTemplates>
-                                        <DataTemplate DataType="system:String">
-                                            <AccessText Text="{CompiledBinding}" />
-                                        </DataTemplate>
-                                    </ContentPresenter.DataTemplates>
-                                </ContentPresenter>
-                                <TextBlock x:Name="PART_InputGestureText"
-                                           Grid.Column="2"
-                                           Margin="24 0 0 0"
-                                           Text="{TemplateBinding InputGesture, Converter={x:Static MenuConverters.KeyGesture}}"
-                                           HorizontalAlignment="Right"
-                                           FontSize="12"
-                                           Foreground="{DynamicResource TextFillColor3}"
-                                           FontWeight="SemiBold"
-                                           VerticalAlignment="Center" />
+                            <ContentPresenter Name="PART_HeaderPresenter"
+                                              Content="{TemplateBinding Header}"
+                                              VerticalAlignment="Center"
+                                              HorizontalAlignment="Stretch"
+                                              Grid.Column="1">
+                                <ContentPresenter.DataTemplates>
+                                    <DataTemplate DataType="system:String">
+                                        <AccessText Text="{CompiledBinding}" />
+                                    </DataTemplate>
+                                </ContentPresenter.DataTemplates>
+                            </ContentPresenter>
+                            <TextBlock x:Name="PART_InputGestureText"
+                                       Grid.Column="2"
+                                       Margin="24 0 0 0"
+                                       Text="{TemplateBinding InputGesture, Converter={x:Static MenuConverters.KeyGesture}}"
+                                       HorizontalAlignment="Right"
+                                       FontSize="12"
+                                       Foreground="{DynamicResource TextFillColor3}"
+                                       FontWeight="SemiBold"
+                                       VerticalAlignment="Center" />
 
-                                <PathIcon Name="PART_ChevronIcon" Grid.Column="3"
-                                          Margin="24 0 0 0"
-                                          Width="10"
-                                          Height="10"
-                                          Data="{StaticResource ChevronRightRegular}" />
-                            </Grid>
-                        </RippleEffect>
-                    </Border>
+                            <PathIcon Name="PART_ChevronIcon" Grid.Column="3"
+                                      Margin="24 0 0 0"
+                                      Width="10"
+                                      Height="10"
+                                      Data="{StaticResource ChevronRightRegular}" />
+                        </Grid>
+                    </RippleEffect>
+
                     <Popup Name="PART_Popup"
                            WindowManagerAddShadowHint="False"
                            Placement="Right"
@@ -132,22 +132,18 @@
                                       Margin="6 4 6 6"
                                       BlurRadius="5"
                                       Offset="0 1"
-                                      ShadowColor="#3C000000">
-                            <Border Background="{DynamicResource BackgroundColor1}"
-                                    BorderBrush="{DynamicResource ControlBorderColor}"
-                                    BorderThickness="1"
-                                    MaxWidth="456"
-                                    MinHeight="32"
-                                    HorizontalAlignment="Stretch"
-                                    CornerRadius="{DynamicResource ControlCornerRadius}">
-                                <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                                              VerticalScrollBarVisibility="Auto">
-                                    <ItemsPresenter Name="PART_ItemsPresenter"
-                                                    ItemsPanel="{TemplateBinding ItemsPanel}"
-                                                    Margin="0 2 0 2"
-                                                    Grid.IsSharedSizeScope="True" />
-                                </ScrollViewer>
-                            </Border>
+                                      ShadowColor="#3C000000"
+                                      Background="{DynamicResource BackgroundColor1}"
+                                      MaxWidth="456"
+                                      MinHeight="32"
+                                      HorizontalAlignment="Stretch">
+                            <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                          VerticalScrollBarVisibility="Auto">
+                                <ItemsPresenter Name="PART_ItemsPresenter"
+                                                ItemsPanel="{TemplateBinding ItemsPanel}"
+                                                Margin="0 2 0 2"
+                                                Grid.IsSharedSizeScope="True" />
+                            </ScrollViewer>
                         </ShadowBorder>
                     </Popup>
                 </Panel>

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/TextBox.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/TextBox.axaml
@@ -33,11 +33,6 @@
         <Setter Property="MinWidth" Value="64" />
         <Setter Property="MinHeight" Value="32" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions> 
-        </Setter> 
 
         <Setter Property="ContextFlyout">
             <MenuFlyout Placement="Bottom">
@@ -71,7 +66,13 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding CornerRadius}"
-                            IsHitTestVisible="False" />
+                            IsHitTestVisible="False">
+                        <Border.Transitions>
+                            <Transitions>
+                                <BrushTransition Property="Background" Duration="0:0:0.1" />
+                            </Transitions>
+                        </Border.Transitions>
+                    </Border>
 
                     <DataValidationErrors>
                         <Grid ColumnDefinitions="Auto,*,Auto">

--- a/src/PleasantUI/Styling/ControlThemes/BasicControls/Window.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/BasicControls/Window.axaml
@@ -5,7 +5,7 @@
         <Setter Property="Background" Value="{DynamicResource BackgroundColor1}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColor1}" />
         <Setter Property="FontSize" Value="{StaticResource GlobalFontSize}" />
-        <Setter Property="FontFamily" Value="{Binding Font, Source={x:Static PleasantSettings.Current}}" />
+        <Setter Property="FontFamily" Value="{DynamicResource GlobalFontFamily}" />
         
         <Setter Property="Template">
             <ControlTemplate>

--- a/src/PleasantUI/Styling/ControlThemes/Controls.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/Controls.axaml
@@ -191,7 +191,7 @@
     </Style>
     
     <Style Selector=":is(Popup)">
-        <Setter Property="(TextElement.FontFamily)" Value="{Binding Font, Source={x:Static PleasantSettings.Current}}" />
+        <Setter Property="(TextElement.FontFamily)" Value="{DynamicResource GlobalFontFamily}" />
     </Style>
     
     <Style Selector=":is(Popup) ShadowBorder">

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/BreadcrumbBar.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/BreadcrumbBar.axaml
@@ -33,11 +33,7 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColor2}" />
         <Setter Property="Cursor" Value="Hand" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
+        
         <Setter Property="Template">
             <ControlTemplate>
                 <RippleEffect Name="PART_Ripple"
@@ -45,6 +41,12 @@
                               BorderBrush="{TemplateBinding BorderBrush}"
                               BorderThickness="{TemplateBinding BorderThickness}"
                               CornerRadius="{TemplateBinding CornerRadius}">
+                    <RippleEffect.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </RippleEffect.Transitions>
+                    
                     <ContentPresenter Name="PART_ContentPresenter"
                                       Content="{TemplateBinding Content}"
                                       ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/Chrome/PleasantCaptionButtons.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/Chrome/PleasantCaptionButtons.axaml
@@ -31,20 +31,20 @@
                     <Button Name="PART_FullScreenButton"
                             IsVisible="False"
                             WindowDecorationProperties.ElementRole="FullScreenButton">
-                        <PleasantIcon Width="10" Height="10" />
+                        <PleasantIcon Width="10" Height="10" RenderOptions.BitmapInterpolationMode="HighQuality" />
                     </Button>
                     <Button Name="PART_MinimizeButton"
                             WindowDecorationProperties.ElementRole="MinimizeButton">
-                        <PleasantIcon Icon="{StaticResource SubtractRegular}" Width="10" Height="10" />
+                        <PleasantIcon Icon="{StaticResource SubtractRegular}" RenderOptions.BitmapInterpolationMode="HighQuality" Width="10" Height="10" />
                     </Button>
                     <Button Name="PART_MaximizeButton"
                             WindowDecorationProperties.ElementRole="MaximizeButton">
-                        <PleasantIcon Width="10" Height="10" />
+                        <PleasantIcon Width="10" Height="10" RenderOptions.BitmapInterpolationMode="HighQuality" />
                     </Button>
                     <Button Name="PART_CloseButton"
                             WindowDecorationProperties.ElementRole="CloseButton"
                             Theme="{StaticResource CloseButtonTheme}">
-                        <PleasantIcon Icon="{StaticResource DismissRegular}" Width="10" Height="10" />
+                        <PleasantIcon Icon="{StaticResource DismissRegular}" RenderOptions.BitmapInterpolationMode="HighQuality" Width="10" Height="10" />
                     </Button>
                 </StackPanel>
             </ControlTemplate>

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/Chrome/PleasantTitleBar.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/Chrome/PleasantTitleBar.axaml
@@ -56,9 +56,16 @@
                                 Spacing="5"
                                 VerticalAlignment="Center"
                                 IsHitTestVisible="False">
-                        <PleasantIcon x:Name="PART_DisplayIcon" Width="16" Height="16" Margin="10 0 5 0" />
+                        <PleasantIcon x:Name="PART_DisplayIcon"
+                                      RenderOptions.BitmapInterpolationMode="HighQuality"
+                                      Width="16"
+                                      Height="16"
+                                      Margin="10 0 5 0" />
 
-                        <PleasantIcon x:Name="PART_DisplayTitle" MaxWidth="75" />
+                        <PleasantIcon x:Name="PART_DisplayTitle"
+                                      RenderOptions.BitmapInterpolationMode="HighQuality"
+                                      MaxHeight="10"
+                                      MaxWidth="75" />
 
                         <TextBlock x:Name="PART_Subtitle"
                                    FontSize="12"

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/ContentDialog.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/ContentDialog.axaml
@@ -53,6 +53,7 @@
                               VerticalAlignment="{TemplateBinding VerticalAlignment}"
                               HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                               BorderThickness="{TemplateBinding BorderThickness}"
+                              Padding="{TemplateBinding Padding}"
                               KeyboardNavigation.TabNavigation="Cycle"
                               ClipContentToBounds="True"
                               BlurRadius="60"

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/MarkedTextBox.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/MarkedTextBox.axaml
@@ -33,12 +33,6 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="(IconHelper.Width)" Value="16" />
         <Setter Property="(IconHelper.Height)" Value="16" />
-        
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions> 
-        </Setter> 
 
         <Setter Property="ContextFlyout">
             <MenuFlyout Placement="Bottom">
@@ -73,6 +67,12 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding CornerRadius}"
                             ClipToBounds="True">
+                        <Border.Transitions>
+                            <Transitions>
+                                <BrushTransition Property="Background" Duration="0:0:0.1" />
+                            </Transitions>
+                        </Border.Transitions>
+                        
                         <DataValidationErrors>
                             <Grid ColumnDefinitions="Auto,*,Auto">
                                 <Border x:Name="SymbolBox"

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/PleasantIcon.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/PleasantIcon.axaml
@@ -10,7 +10,7 @@
         </Setter>
 
         <Setter Property="Template">
-            <ControlTemplate>
+            <ControlTemplate TargetType="PleasantIcon">
                 <ContentPresenter Name="PART_ContentPresenter"
                                   Background="{TemplateBinding Background}"
                                   Foreground="{TemplateBinding Foreground}"
@@ -28,7 +28,8 @@
                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=PleasantIcon}}" />
                         </DataTemplate>
                         <DataTemplate DataType="IImage">
-                            <Image Source="{Binding}" Width="{Binding (IconHelper.Width), RelativeSource={RelativeSource AncestorType=PleasantIcon}}" Height="{Binding (IconHelper.Height), RelativeSource={RelativeSource AncestorType=PleasantIcon}}" />
+                            <Image Source="{Binding}" Width="{Binding (IconHelper.Width), RelativeSource={RelativeSource AncestorType=PleasantIcon}}" 
+                                   Height="{Binding (IconHelper.Height), RelativeSource={RelativeSource AncestorType=PleasantIcon}}" />
                         </DataTemplate>
                     </ContentPresenter.DataTemplates>
                 </ContentPresenter>

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/PleasantMiniWindow.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/PleasantMiniWindow.axaml
@@ -12,7 +12,7 @@
                 Value="{CompiledBinding WindowSettings.EnableCustomTitleBar, Source={x:Static PleasantSettings.Current}}" />
         <Setter Property="Background" Value="{DynamicResource BackgroundColor1}" />
         <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource BackgroundColor1}" />
-        <Setter Property="FontFamily" Value="{Binding Font, Source={x:Static PleasantSettings.Current}}" />
+        <Setter Property="FontFamily" Value="{DynamicResource GlobalFontFamily}" />
         <Setter Property="UseLayoutRounding" Value="True" />
         <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="8" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColor1}" />

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/PleasantTabItem.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/PleasantTabItem.axaml
@@ -34,53 +34,49 @@
         <Setter Property="Width" Value="190" />
         <Setter Property="(CompositionAnimationBehavior.UseEntranceAnimations)" Value="True" />
         <Setter Property="(CompositionAnimationBehavior.UseImplicitAnimations)" Value="True" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
-        
+
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Name="PART_LayoutRoot"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        Background="{TemplateBinding Background}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
-                    <RippleEffect Name="PART_Ripple" Padding="{TemplateBinding Padding}" CornerRadius="{TemplateBinding CornerRadius}">
-                        <Grid ColumnDefinitions="*,Auto">
-                            <ContentPresenter Grid.Column="0" Name="PART_ContentPresenter"
-                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                              Content="{TemplateBinding Header}"
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              TextBlock.FontFamily="{TemplateBinding FontFamily}"
-                                              TextBlock.FontSize="{TemplateBinding FontSize}"
-                                              TextBlock.FontWeight="{TemplateBinding FontWeight}"
-                                              TextBlock.TextTrimming="CharacterEllipsis" />
+                <RippleEffect Name="PART_Ripple"
+                              Padding="{TemplateBinding Padding}"
+                              CornerRadius="{TemplateBinding CornerRadius}"
+                              BorderBrush="{TemplateBinding BorderBrush}"
+                              BorderThickness="{TemplateBinding BorderThickness}"
+                              Background="{TemplateBinding Background}">
+                    <RippleEffect.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </RippleEffect.Transitions>
 
-                            <Button Grid.Column="1"
-                                    Name="PART_CloseButton"
-                                    Theme="{StaticResource CloseButtonTheme}"
-                                    MinWidth="0"
-                                    VerticalAlignment="Center"
-                                    Padding="5"
-                                    Margin="5 0 0 0"
-                                    ToolTip.Tip="{Localize Close, Default='Close'}">
-                                <PleasantIcon Width="8" Height="8" Icon="{StaticResource DismissRegular}" />
-                            </Button>
-                        </Grid>
-                    </RippleEffect>
-                </Border>
+                    <Grid ColumnDefinitions="*,Auto">
+                        <ContentPresenter Grid.Column="0" Name="PART_ContentPresenter"
+                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                          Content="{TemplateBinding Header}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          TextBlock.FontFamily="{TemplateBinding FontFamily}"
+                                          TextBlock.FontSize="{TemplateBinding FontSize}"
+                                          TextBlock.FontWeight="{TemplateBinding FontWeight}"
+                                          TextBlock.TextTrimming="CharacterEllipsis" />
+
+                        <Button Grid.Column="1"
+                                Name="PART_CloseButton"
+                                Theme="{StaticResource CloseButtonTheme}"
+                                MinWidth="0"
+                                VerticalAlignment="Center"
+                                Padding="5"
+                                Margin="5 0 0 0"
+                                ToolTip.Tip="{Localize Close, Default='Close'}">
+                            <PleasantIcon Width="8" Height="8" Icon="{StaticResource DismissRegular}" />
+                        </Button>
+                    </Grid>
+                </RippleEffect>
             </ControlTemplate>
         </Setter>
-        
+
         <Style Selector="^ /template/ RippleEffect#PART_Ripple">
             <Setter Property="RippleFill" Value="{DynamicResource ControlFillColor3}" />
-        </Style>
-
-        <Style Selector="^ /template/ Border#PART_LayoutRoot">
-            <Setter Property="Background" Value="{CompiledBinding $parent[PleasantTabItem].Background}" />
         </Style>
 
         <Style Selector="^:pointerover">

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/PleasantWindow.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/PleasantWindow.axaml
@@ -6,7 +6,7 @@
         <Setter Property="Background" Value="{DynamicResource BackgroundColor1}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColor1}" />
         <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource BackgroundColor1}" />
-        <Setter Property="FontFamily" Value="{Binding Font, Source={x:Static PleasantSettings.Current}}" />
+        <Setter Property="FontFamily" Value="{DynamicResource GlobalFontFamily}" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="UseLayoutRounding" Value="True" />
         <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="8" />

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/PropertyGrid.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/PropertyGrid.axaml
@@ -2,7 +2,6 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:PleasantUI.Controls"
                     x:ClassModifier="internal">
-
     <Design.PreviewWith>
         <Border Padding="20" Background="{DynamicResource BackgroundColor1}" Width="400">
             <controls:PropertyGrid>
@@ -17,19 +16,24 @@
         </Border>
     </Design.PreviewWith>
 
-    <!-- ── PropertyRow ───────────────────────────────────────────────────── -->
     <ControlTheme x:Key="{x:Type controls:PropertyRow}" TargetType="controls:PropertyRow">
         <Setter Property="HorizontalAlignment" Value="Stretch" />
 
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid ColumnDefinitions="Auto,16,*">
-
+                <Grid >
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="PropertyGridLabelColumnGroup" />
+                        <ColumnDefinition Width="16" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    
                     <!-- Label -->
                     <TextBlock Grid.Column="0"
                                Text="{TemplateBinding Label}"
                                Foreground="{DynamicResource TextFillColor2}"
                                FontSize="{StaticResource GlobalFontSize}"
+                               HorizontalAlignment="Left"
                                VerticalAlignment="Center" />
 
                     <!-- Value: plain text (default) -->
@@ -39,6 +43,7 @@
                                FontSize="{StaticResource GlobalFontSize}"
                                TextTrimming="CharacterEllipsis"
                                VerticalAlignment="Center"
+                               HorizontalAlignment="{TemplateBinding ValueHorizontalAlignment}"
                                ToolTip.Tip="{TemplateBinding ToolTipText}" />
 
                     <!-- Value: link button -->
@@ -47,10 +52,12 @@
                             Content="{TemplateBinding Value}"
                             Command="{TemplateBinding LinkCommand}"
                             CommandParameter="{TemplateBinding LinkCommandParameter}"
+                            CornerRadius="4"
                             Theme="{StaticResource AppBarButtonTheme}"
-                            Padding="5 0"
+                            Padding="0"
                             HorizontalContentAlignment="Left"
                             VerticalContentAlignment="Center"
+                            HorizontalAlignment="{TemplateBinding ValueHorizontalAlignment}"
                             Cursor="Hand"
                             IsVisible="False"
                             ToolTip.Tip="{TemplateBinding ToolTipText}">
@@ -60,7 +67,6 @@
                                 <Setter Property="TextBlock.Foreground" Value="{DynamicResource TextFillColor1}" />
                             </Style>
                             <Style Selector="Button:pointerover /template/ ContentPresenter">
-                                <Setter Property="TextBlock.Foreground" Value="{DynamicResource AccentFillColor1}" />
                                 <Setter Property="TextBlock.TextDecorations" Value="Underline" />
                             </Style>
                         </Button.Styles>
@@ -74,6 +80,7 @@
                                Foreground="{TemplateBinding ValueBrush}"
                                FontWeight="SemiBold"
                                VerticalAlignment="Center"
+                               HorizontalAlignment="{TemplateBinding ValueHorizontalAlignment}"
                                IsVisible="False"
                                ToolTip.Tip="{TemplateBinding ToolTipText}" />
 
@@ -83,6 +90,7 @@
                                       Content="{TemplateBinding Value}"
                                       ContentTemplate="{TemplateBinding ValueTemplate}"
                                       VerticalAlignment="Center"
+                                      HorizontalAlignment="{TemplateBinding ValueHorizontalAlignment}"
                                       IsVisible="False" />
                 </Grid>
             </ControlTemplate>
@@ -113,7 +121,6 @@
         </Style>
     </ControlTheme>
 
-    <!-- ── PropertyGrid ──────────────────────────────────────────────────── -->
     <ControlTheme x:Key="{x:Type controls:PropertyGrid}" TargetType="controls:PropertyGrid">
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="RowSpacing" Value="10" />
@@ -122,11 +129,10 @@
             <ControlTemplate>
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                               VerticalScrollBarVisibility="Auto">
-                    <ItemsControl Name="PART_RowsHost">
+                    <ItemsControl Name="PART_RowsHost" ItemsSource="{TemplateBinding Rows}" Grid.IsSharedSizeScope="True">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <StackPanel
-                                    Spacing="{Binding RowSpacing, RelativeSource={RelativeSource AncestorType=controls:PropertyGrid}}" />
+                                <StackPanel Spacing="{Binding RowSpacing, RelativeSource={RelativeSource AncestorType=controls:PropertyGrid}}" />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                     </ItemsControl>
@@ -134,5 +140,4 @@
             </ControlTemplate>
         </Setter>
     </ControlTheme>
-
 </ResourceDictionary>

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/SearchableComboBox.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/SearchableComboBox.axaml
@@ -26,11 +26,6 @@
         <Setter Property="Background" Value="{ColorToTransparent ControlFillColor2}" />
         <Setter Property="Padding" Value="11 5 11 7" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
 
         <Setter Property="Template">
             <ControlTemplate>
@@ -42,6 +37,12 @@
                         CornerRadius="{TemplateBinding CornerRadius}"
                         ClipToBounds="True"
                         TemplatedControl.IsTemplateFocusTarget="True">
+                    <Border.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </Border.Transitions>
+                    
                     <RippleEffect x:Name="PART_Ripple">
                         <Panel>
                             <Border Name="Pill" Theme="{StaticResource ComboBoxItemPillBorder}" />
@@ -144,11 +145,6 @@
                 <VirtualizingStackPanel />
             </ItemsPanelTemplate>
         </Setter>
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
 
         <Setter Property="Template">
             <ControlTemplate>
@@ -170,7 +166,13 @@
                                       BorderBrush="{TemplateBinding BorderBrush}"
                                       BorderThickness="{TemplateBinding BorderThickness}"
                                       MinWidth="64"
-                                      CornerRadius="{TemplateBinding CornerRadius}" />
+                                      CornerRadius="{TemplateBinding CornerRadius}">
+                            <RippleEffect.Transitions>
+                                <Transitions>
+                                    <BrushTransition Property="Background" Duration="0:0:0.1" />
+                                </Transitions>
+                            </RippleEffect.Transitions>
+                        </RippleEffect>
 
                         <TextBlock x:Name="PlaceholderTextBlock"
                                    Grid.Row="1"

--- a/src/PleasantUI/Styling/ControlThemes/PleasantControls/SelectionList.axaml
+++ b/src/PleasantUI/Styling/ControlThemes/PleasantControls/SelectionList.axaml
@@ -9,11 +9,6 @@
         <Setter Property="Padding" Value="8" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.1" />
-            </Transitions>
-        </Setter>
         
         <Setter Property="Template">
             <ControlTemplate TargetType="controls:SelectionListItem">
@@ -25,6 +20,12 @@
                         Padding="{TemplateBinding Padding}"
                         Margin="2"
                         ClipToBounds="True">
+                    <Border.Transitions>
+                        <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.1" />
+                        </Transitions>
+                    </Border.Transitions>
+                    
                     <Grid ColumnDefinitions="Auto,*">
                         <!-- Image / icon area — hidden by :no-image pseudo-class -->
                         <Border Name="ImageBorder"

--- a/tests/PleasantUI.Tests/PleasantUI.Tests.csproj
+++ b/tests/PleasantUI.Tests/PleasantUI.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Headless" Version="12.1.0" />
-        <PackageReference Include="Avalonia.Headless.XUnit" Version="12.1.0" />
-        <PackageReference Include="Avalonia.Win32" Version="12.1.0" />
+        <PackageReference Include="Avalonia.Headless" Version="12.1.1" />
+        <PackageReference Include="Avalonia.Headless.XUnit" Version="12.1.1" />
+        <PackageReference Include="Avalonia.Win32" Version="12.1.1" />
         <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR fixes the following bugs that were discovered while creating my own and as yet unannounced project:

- Fixed an issue where the color of buttons would flicker when hovering too much. This is more noticeable when hovering over buttons in the TitleBar.
- Fixed the `PropertyGrid` and removed the LabelColumnWidth property, as this property was not used anywhere.
- The window title and icon display have been fixed. If you haven't specified a `DisplayIcon`, it should be taken from the Icon property. A `10px` height limit has been added for `DisplayTitle`, and the title text should now be displayed if not specified.

Changed:
- Updated to Avalonia 12.1.1.
- Improved logging to allow viewing task errors and Avalonia warnings, such as in Binding, for `PleasantUI.Example`.
- HotAvalonia has been removed as it failed to demonstrate effectiveness in developing `PleasantUI`.